### PR TITLE
Fixes a bug that prevented to operate in non-bentobox worlds

### DIFF
--- a/src/main/java/com/ssomar/score/usedapi/BentoBoxAPI.java
+++ b/src/main/java/com/ssomar/score/usedapi/BentoBoxAPI.java
@@ -30,18 +30,20 @@ public class BentoBoxAPI {
         // Checks if player is allowed to break blocks on island he is standing on,
         // or if he is allowed to break blocks in the world outside protection area.
 
-        return BentoBox.getInstance().getIslandsManager().getIslandAt(location).
-            map(island -> island.isAllowed(User.getInstance(pUUID), Flags.BREAK_BLOCKS)).
-            orElse(Flags.BREAK_BLOCKS.isSetForWorld(location.getWorld()));
+        return !BentoBox.getInstance().getIWM().inWorld(location.getWorld()) ||
+            BentoBox.getInstance().getIslandsManager().getIslandAt(location).
+                map(island -> island.isAllowed(User.getInstance(pUUID), Flags.BREAK_BLOCKS)).
+                orElse(Flags.BREAK_BLOCKS.isSetForWorld(location.getWorld()));
     }
 
     public static boolean playerCanPlaceIslandBlock(@NotNull UUID pUUID, @NotNull Location location) {
         // Checks if player is allowed to place blocks on island he is standing on,
         // or if he is allowed to place blocks in the world outside protection area.
 
-        return BentoBox.getInstance().getIslandsManager().getIslandAt(location).
-            map(island -> island.isAllowed(User.getInstance(pUUID), Flags.PLACE_BLOCKS)).
-            orElse(Flags.PLACE_BLOCKS.isSetForWorld(location.getWorld()));
+        return !BentoBox.getInstance().getIWM().inWorld(location.getWorld()) ||
+            BentoBox.getInstance().getIslandsManager().getIslandAt(location).
+                map(island -> island.isAllowed(User.getInstance(pUUID), Flags.PLACE_BLOCKS)).
+                orElse(Flags.PLACE_BLOCKS.isSetForWorld(location.getWorld()));
     }
 
     public static World getWorld(String worldStr) {


### PR DESCRIPTION
There was missing a check if the world is BentoBox world. Without that check, all other worlds acts like BentoBox is preventing something, while actually it should not.