### PR TITLE
Variables-Define

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,15 +78,15 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>8</source>
-                    <target>8</target>
+                    <source>14</source>
+                    <target>14</target>
                     <encoding>${project.build.sourceEncoding}</encoding>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.4.1</version>
                 <!-- Do not include the <configuration>...</configuration> part if you
                     are using Sponge! -->
                 <configuration>
@@ -581,7 +581,7 @@
         <dependency>
             <groupId>com.github.Ssomar-Developement</groupId>
             <artifactId>SEvents</artifactId>
-            <version>22ad289cbf</version>
+            <version>22ad289</version>
             <scope>compile</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -78,8 +78,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>14</source>
-                    <target>14</target>
+                    <source>8</source>
+                    <target>8</target>
                     <encoding>${project.build.sourceEncoding}</encoding>
                 </configuration>
             </plugin>

--- a/src/main/java/com/ssomar/score/commands/score/CommandsClass.java
+++ b/src/main/java/com/ssomar/score/commands/score/CommandsClass.java
@@ -623,10 +623,10 @@ public final class CommandsClass implements CommandExecutor, TabExecutor {
                         // Type Check
                         if( args[1] == null) throw new IllegalArgumentException("Command format: /score variables-define NAME TYPE SCOPE MATERIAL default values...");
                         switch (args[1].toLowerCase()) {
-                            case "string" -> variable.getType().setValue(Optional.of(VariableType.STRING));
-                            case "list" -> variable.getType().setValue(Optional.of(VariableType.LIST));
-                            case "number" -> variable.getType().setValue(Optional.of(VariableType.NUMBER));
-                            default -> throw new IllegalArgumentException("You must pick between STRING, LIST, OR NUMBER for the type! You picked: " + args[1] );
+                            case "string": variable.getType().setValue(Optional.of(VariableType.STRING)); break;
+                            case "list" : variable.getType().setValue(Optional.of(VariableType.LIST)); break;
+                            case "number" : variable.getType().setValue(Optional.of(VariableType.NUMBER)); break;
+                            default : throw new IllegalArgumentException("You must pick between STRING, LIST, OR NUMBER for the type! You picked: " + args[1] );
                         }
 
                         // Scope Check


### PR DESCRIPTION
Pomxml: only changed the shading plugin to be compatible with my IDE from 3.1.0 -> 3.4.1 as well as changed a dependency that was being stupid here:

        <dependency>
            <groupId>com.github.Ssomar-Developement</groupId>
            <artifactId>SEvents</artifactId>
            <version>22ad289</version>
            <scope>compile</scope>
        </dependency>

CommandsClass.java: Added /score variables-define NAME TYPE SCOPE MATERIAL default arguments...

No duplicate file/variable checking.
Erroneous arguments checking implemented.
Tab-complete implemented.
Works with file paths in the name. For example /score variables-define filepath1/filepath2/name ...more arguments

Tested-by: Zestybuffalo

Tests: erroneous arguments - Works.
Tests: All correct arguments - works
Tests: Duplicate variable creation - Behavior undefined. Server owner should be responsible for preventing this, since variables-create doesn't check either. At this point

Additional notes:
I noticed something during testing.

Creating a variable "weirdpapibehavior" and trying to parse %score_variables_weirdpapibehaviorDOESNOTEXIST% will return weirdpapibehavior's data instead of "Variable not found". Video is linked here: [VIDEO](https://cdn.discordapp.com/attachments/1325355862679617536/1335693219400257536/Screen_Recording_2025-02-02_at_2.25.47_PM.mov?ex=67a118bf&is=679fc73f&hm=245a0a4a6468ccec6b9f5127af8de7ab29fa46c68f9b2fc4eb96f4ab27324479&)
alt= https://cdn.discordapp.com/attachments/1325355862679617536/1335693219400257536/Screen_Recording_2025-02-02_at_2.25.47_PM.mov?ex=67a118bf&is=679fc73f&hm=245a0a4a6468ccec6b9f5127af8de7ab29fa46c68f9b2fc4eb96f4ab27324479&

NOTE: I do NOT believe it has anything to do with /score variables-define. It happens on every variable on my server, but I hadn't checked if it happened on earlier versions. Hopefully you can check.