### PR TITLE
Customcond ifsheepcolor

### DIFF
--- a/src/main/java/com/ssomar/particles/commands/ShapesManager.java
+++ b/src/main/java/com/ssomar/particles/commands/ShapesManager.java
@@ -24,16 +24,18 @@ public class ShapesManager {
 
         // Loop that clears the running shapes every 10 seconds
         Runnable task = () -> {
-            for (Entity entity : runningShapes.keySet()) {
+            Iterator<Entity> iterator = runningShapes.keySet().iterator();
+            while (iterator.hasNext()) {
+                Entity entity = iterator.next();
                 if (entity instanceof Player) {
                     if(!((Player) entity).isOnline()){
-                        runningShapes.remove(entity);
+                        iterator.remove();
                         continue;
                     }
                     endedShapes(entity);
                 }
                 else if(entity.isDead()){
-                    runningShapes.remove(entity);
+                    iterator.remove();
                 }
             }
         };

--- a/src/main/java/com/ssomar/score/commands/runnable/mixed_player_entity/commands/AddTemporaryAttribute.java
+++ b/src/main/java/com/ssomar/score/commands/runnable/mixed_player_entity/commands/AddTemporaryAttribute.java
@@ -1,11 +1,11 @@
 package com.ssomar.score.commands.runnable.mixed_player_entity.commands;
+import com.ssomar.score.utils.backward_compatibility.AttributeUtils;
 
 import com.ssomar.score.SCore;
 import com.ssomar.score.commands.runnable.SCommandToExec;
 import com.ssomar.score.commands.runnable.mixed_player_entity.MixedCommand;
 import org.bukkit.ChatColor;
 import org.bukkit.NamespacedKey;
-import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.entity.Entity;
@@ -15,52 +15,13 @@ import org.bukkit.attribute.AttributeModifier.Operation;
 import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.UUID;
 
 /**
  * When used, it gives the target player/entity a given attribute for a set period of time.
  * The attribute provided by this custom command does not set the value, but gives a modifier.
  */
 public class AddTemporaryAttribute extends MixedCommand  {
-    private static HashMap<String, Attribute> attributeHashMap = new HashMap<>();
-
-    static {
-        attributeHashMap.put("ARMOR", Attribute.ARMOR);
-        attributeHashMap.put("ARMOR_TOUGHNESS", Attribute.ARMOR_TOUGHNESS);
-        attributeHashMap.put("ATTACK_DAMAGE", Attribute.ATTACK_DAMAGE);
-        attributeHashMap.put("ATTACK_KNOCKBACK", Attribute.ATTACK_KNOCKBACK);
-        attributeHashMap.put("ATTACK_SPEED", Attribute.ATTACK_SPEED);
-        attributeHashMap.put("BLOCK_BREAK_SPEED", Attribute.BLOCK_BREAK_SPEED);
-        attributeHashMap.put("BLOCK_INTERACTION_RANGE", Attribute.BLOCK_INTERACTION_RANGE);
-        attributeHashMap.put("BURNING_TIME", Attribute.BURNING_TIME);
-        attributeHashMap.put("ENTITY_INTERACTION_RANGE", Attribute.ENTITY_INTERACTION_RANGE);
-        attributeHashMap.put("EXPLOSION_KNOCKBACK_RESISTANCE", Attribute.EXPLOSION_KNOCKBACK_RESISTANCE);
-        attributeHashMap.put("FALL_DAMAGE_MULTIPLIER", Attribute.FALL_DAMAGE_MULTIPLIER);
-        attributeHashMap.put("FLYING_SPEED", Attribute.FLYING_SPEED);
-        attributeHashMap.put("FOLLOW_RANGE", Attribute.FOLLOW_RANGE);
-        attributeHashMap.put("GRAVITY", Attribute.GRAVITY);
-        attributeHashMap.put("JUMP_STRENGTH", Attribute.JUMP_STRENGTH);
-        attributeHashMap.put("KNOCKBACK_RESISTANCE", Attribute.KNOCKBACK_RESISTANCE);
-        attributeHashMap.put("LUCK", Attribute.LUCK);
-        attributeHashMap.put("MAX_ABSORPTION", Attribute.MAX_ABSORPTION);
-        attributeHashMap.put("MAX_HEALTH", Attribute.MAX_HEALTH);
-        attributeHashMap.put("MINING_EFFICIENCY", Attribute.MINING_EFFICIENCY);
-        attributeHashMap.put("MOVEMENT_EFFICIENCY", Attribute.MOVEMENT_EFFICIENCY);
-        attributeHashMap.put("MOVEMENT_SPEED", Attribute.MOVEMENT_SPEED);
-        attributeHashMap.put("OXYGEN_BONUS", Attribute.OXYGEN_BONUS);
-        attributeHashMap.put("SAFE_FALL_DISTANCE", Attribute.SAFE_FALL_DISTANCE);
-        attributeHashMap.put("SCALE", Attribute.SCALE);
-        attributeHashMap.put("SPAWN_REINFORCEMENTS", Attribute.SPAWN_REINFORCEMENTS);
-        attributeHashMap.put("SNEAKING_SPEED", Attribute.SNEAKING_SPEED);
-        attributeHashMap.put("STEP_HEIGHT", Attribute.STEP_HEIGHT);
-        attributeHashMap.put("SUBMERGED_MINING_SPEED", Attribute.SUBMERGED_MINING_SPEED);
-        attributeHashMap.put("SWEEPING_DAMAGE_RATIO", Attribute.SWEEPING_DAMAGE_RATIO);
-        attributeHashMap.put("TEMPT_RANGE", Attribute.TEMPT_RANGE);
-        attributeHashMap.put("WATER_MOVEMENT_EFFICIENCY", Attribute.WATER_MOVEMENT_EFFICIENCY);
-    }
-
 
     @Override
     public List<String> getNames() {
@@ -95,7 +56,7 @@ public class AddTemporaryAttribute extends MixedCommand  {
         // arg3: timeinticks
 
         // invalid attribute checker
-        if (!attributeHashMap.containsKey(args.get(0))) {
+        if (!AttributeUtils.getAttributes().containsKey(args.get(0))) {
             SCore.plugin.getLogger().info("[ADD_TEMPORARY_ATTRIBUTE] Invalid Attribute argument was provided for field attribute: "+args.get(0));
             return;
         }
@@ -141,10 +102,10 @@ public class AddTemporaryAttribute extends MixedCommand  {
         // if the target is a Player, cast the entity as a player.
         if (entity instanceof Player) {
             Player playerEntity = (Player) entity;
-            attrInstance = playerEntity.getAttribute(attributeHashMap.get(args.get(0)));
+            attrInstance = playerEntity.getAttribute(AttributeUtils.getAttribute(args.get(0)));
         } else {
             LivingEntity livingEntity = (LivingEntity) entity;
-            attrInstance = livingEntity.getAttribute((attributeHashMap.get(args.get(0))));
+            attrInstance = livingEntity.getAttribute((AttributeUtils.getAttribute(args.get(0))));
         }
 
         NamespacedKey key = NamespacedKey.minecraft(args.get(0).toLowerCase());

--- a/src/main/java/com/ssomar/score/features/FeatureSettingsSCore.java
+++ b/src/main/java/com/ssomar/score/features/FeatureSettingsSCore.java
@@ -260,6 +260,7 @@ public enum FeatureSettingsSCore implements FeatureSettingsInterface {
     ifPosY(getFeatureSettings("ifPosY", SavingVerbosityLevel.SAVE_ONLY_WHEN_DIFFERENT_DEFAULT)),
     ifPosZ(getFeatureSettings("ifPosZ", SavingVerbosityLevel.SAVE_ONLY_WHEN_DIFFERENT_DEFAULT)),
     ifPowered(getFeatureSettings("ifPowered", SavingVerbosityLevel.SAVE_ONLY_WHEN_DIFFERENT_DEFAULT)),
+    ifSheepColor(getFeatureSettings("ifSheepColor", SavingVerbosityLevel.SAVE_ONLY_WHEN_DIFFERENT_DEFAULT)),
     ifSneaking(getFeatureSettings("ifSneaking", SavingVerbosityLevel.SAVE_ONLY_WHEN_DIFFERENT_DEFAULT)),
     ifSprinting(getFeatureSettings("ifSprinting", SavingVerbosityLevel.SAVE_ONLY_WHEN_DIFFERENT_DEFAULT)),
     ifStunned(getFeatureSettings("ifStunned", SavingVerbosityLevel.SAVE_ONLY_WHEN_DIFFERENT_DEFAULT)),

--- a/src/main/java/com/ssomar/score/features/custom/conditions/entity/condition/IfSheepColor.java
+++ b/src/main/java/com/ssomar/score/features/custom/conditions/entity/condition/IfSheepColor.java
@@ -1,0 +1,69 @@
+package com.ssomar.score.features.custom.conditions.entity.condition;
+
+import com.ssomar.score.features.FeatureParentInterface;
+import com.ssomar.score.features.FeatureSettingsSCore;
+import com.ssomar.score.features.custom.conditions.entity.EntityConditionFeature;
+import com.ssomar.score.features.custom.conditions.entity.EntityConditionRequest;
+import com.ssomar.score.features.types.list.ListUncoloredStringFeature;
+import com.ssomar.score.utils.strings.StringConverter;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Sheep;
+
+import java.util.ArrayList;
+import java.util.Optional;
+
+public class IfSheepColor extends EntityConditionFeature<ListUncoloredStringFeature, IfSheepColor> {
+    public IfSheepColor(FeatureParentInterface parent) {
+        super(parent, FeatureSettingsSCore.ifSheepColor);
+    }
+
+    @Override
+    public boolean verifCondition(EntityConditionRequest request) {
+        if (hasCondition()) {
+
+
+            Entity entity = request.getEntity();
+            // return false automatically if entity is not sheep
+            if (!(entity instanceof Sheep)) return false;
+
+            boolean notValid = true;
+            for (String name : getCondition().getValue(request.getSp())) {
+                if (StringConverter.decoloredString(
+                        String.valueOf(
+                                ((Sheep) entity).getColor()
+                        )
+                ).equals(name)) {
+                    notValid = false;
+                    break;
+                }
+            }
+
+            if (notValid) {
+                runInvalidCondition(request);
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public void subReset() {
+        setCondition(new ListUncoloredStringFeature(getParent(), new ArrayList<>(), FeatureSettingsSCore.ifSheepColor, Optional.empty()));
+    }
+
+    @Override
+    public boolean hasCondition() {
+        return !getCondition().getValue().isEmpty();
+    }
+
+    @Override
+    public IfSheepColor getNewInstance(FeatureParentInterface newParent) {
+        return new IfSheepColor(newParent);
+    }
+
+    @Override
+    public IfSheepColor getValue() {
+        return this;
+    }
+}

--- a/src/main/java/com/ssomar/score/features/custom/conditions/entity/parent/EntityConditionsFeature.java
+++ b/src/main/java/com/ssomar/score/features/custom/conditions/entity/parent/EntityConditionsFeature.java
@@ -72,6 +72,7 @@ public class EntityConditionsFeature extends FeatureWithHisOwnEditor<EntityCondi
         /* List uncolored string */
         conditions.add(new IfHasTag(this));
         conditions.add(new IfNotHasTag(this));
+        conditions.add(new IfSheepColor(this));
 
         /* List Material with tags */
         conditions.add(new IfIsOnTheBlock(this));
@@ -79,6 +80,7 @@ public class EntityConditionsFeature extends FeatureWithHisOwnEditor<EntityCondi
 
         /* List colored string */
         conditions.add(new IfName(this));
+
 
 
         /* List EntityType */

--- a/src/main/java/com/ssomar/score/features/lang/FeatureSettingsSCoreEN.java
+++ b/src/main/java/com/ssomar/score/features/lang/FeatureSettingsSCoreEN.java
@@ -382,6 +382,7 @@ public enum FeatureSettingsSCoreEN implements FeatureSettingsInterface {
     ifPosY("ifPosY", "If player posY", new String[]{}, Material.ANVIL),
     ifPosZ("ifPosZ", "If player posZ", new String[]{}, Material.ANVIL),
     ifPowered("ifPowered", "If powered", new String[]{}, Material.ANVIL),
+    ifSheepColor("ifSheepColor", "If sheep color", new String[]{}, Material.ANVIL),
     ifSneaking("ifSneaking", "If sneaking", new String[]{}, null),
     ifSprinting("ifSprinting", "If sprinting", new String[]{}, null),
     ifStunned("ifStunned", "If stunned", new String[]{"&7&oBy the custom player", "&7&ocommand &eSTUN_ENABLE"}, null),


### PR DESCRIPTION
- Fixed an issue where ShapesManager was throwing an exception because the previous code was using .remove() on a hashmap it was iterating from by using an Iterator object instead
- Rewrote the code to use AttributeUtils instead of writing my own hashmap to fix the backwards compatibility issue of the ADD_TEMPORARY_ATTRIBUTE custom command
- Added the ifSheepColor entity condition