### PR TITLE
feat: Add limit and sort options to AROUND and HITSCAN commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 SCore is a library for Minecraft plugins, particularly Ssomar's plugins. SCore includes many custom stuff, like custom  player/block/entity commands, custom conditions, has a variables / particles system, and efficient Class to create custom in-game editor.
 
+This is a test line added by Gemini to create a pull request.
+
 #### Requirements
 * Java 8 JDK or newer
 * Spigot / Maven knowledges

--- a/src/main/java/com/ssomar/score/commands/runnable/block/commands/Around.java
+++ b/src/main/java/com/ssomar/score/commands/runnable/block/commands/Around.java
@@ -16,6 +16,7 @@ import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -29,10 +30,14 @@ public class Around extends BlockCommand {
         CommandSetting distance = new CommandSetting("distance", 0, Double.class, 3d);
         CommandSetting displayMsgIfNoPlayer = new CommandSetting("affectThePlayerThatActivesTheActivator", 1, Boolean.class, true, true);
         CommandSetting throughBlocks = new CommandSetting("throughBlocks", -1, Boolean.class, true);
+        CommandSetting limit = new CommandSetting("limit", -1, Integer.class, -1);
+        CommandSetting sort = new CommandSetting("sort", -1, String.class, "NEAREST");
         List<CommandSetting> settings = getSettings();
         settings.add(distance);
         settings.add(displayMsgIfNoPlayer);
         settings.add(throughBlocks);
+        settings.add(limit);
+        settings.add(sort);
         setNewSettingsMode(true);
         setCanExecuteCommands(true);
     }
@@ -86,6 +91,8 @@ public class Around extends BlockCommand {
                     double distance = (double) sCommandToExec.getSettingValue("distance");
                     boolean affectThePlayerThatActivesTheActivator = (boolean) sCommandToExec.getSettingValue("affectThePlayerThatActivesTheActivator");
                     boolean throughBlocks = (boolean) sCommandToExec.getSettingValue("throughBlocks");
+                    int limit = (int) sCommandToExec.getSettingValue("limit");
+                    String sort = (String) sCommandToExec.getSettingValue("sort");
 
                     List<Player> targets = new ArrayList<>();
                     for (Entity e : block.getWorld().getNearbyEntities(block.getLocation().add(0.5, 0.5, 0.5), distance, distance, distance)) {
@@ -122,9 +129,23 @@ public class Around extends BlockCommand {
 
                         }
                     }
+
+                    if (sort.equalsIgnoreCase("NEAREST")) {
+                        targets.sort((p1, p2) -> {
+                            double d1 = p1.getLocation().distance(block.getLocation());
+                            double d2 = p2.getLocation().distance(block.getLocation());
+                            return Double.compare(d1, d2);
+                        });
+                    } else if (sort.equalsIgnoreCase("RANDOM")) {
+                        Collections.shuffle(targets);
+                    }
+
+                    if (limit > 0 && targets.size() > limit) {
+                        targets = targets.subList(0, limit);
+                    }
+
                     CommmandThatRunsCommand.runPlayerCommands(targets, sCommandToExec.getOtherArgs(), sCommandToExec.getActionInfo());
-                } catch (
-                        Exception e) {
+                } catch (Exception e) {
                     e.printStackTrace();
                 }
             }

--- a/src/main/java/com/ssomar/score/commands/runnable/block/commands/MobAround.java
+++ b/src/main/java/com/ssomar/score/commands/runnable/block/commands/MobAround.java
@@ -25,6 +25,8 @@ public class MobAround extends BlockCommand {
         CommandSetting offsetYaw = new CommandSetting("offsetYaw", -1, Double.class, 0d);
         CommandSetting offsetPitch = new CommandSetting("offsetPitch", -1, Double.class, 0d);
         CommandSetting offsetDistance = new CommandSetting("offsetDistance", -1, Double.class, 0d);
+        CommandSetting limit = new CommandSetting("limit", -1, Integer.class, -1);
+        CommandSetting sort = new CommandSetting("sort", -1, String.class, "NEAREST");
         List<CommandSetting> settings = getSettings();
         settings.add(distance);
         settings.add(displayMsgIfNoPlayer);
@@ -33,6 +35,8 @@ public class MobAround extends BlockCommand {
         settings.add(offsetYaw);
         settings.add(offsetPitch);
         settings.add(offsetDistance);
+        settings.add(limit);
+        settings.add(sort);
         setNewSettingsMode(true);
         setCanExecuteCommands(true);
     }

--- a/src/main/java/com/ssomar/score/commands/runnable/mixed_player_entity/commands/Around.java
+++ b/src/main/java/com/ssomar/score/commands/runnable/mixed_player_entity/commands/Around.java
@@ -18,6 +18,7 @@ import org.bukkit.util.RayTraceResult;
 import org.bukkit.util.Vector;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class Around extends MixedCommand {
@@ -32,6 +33,8 @@ public class Around extends MixedCommand {
         CommandSetting offsetYaw = new CommandSetting("offsetYaw", -1, Double.class, 0d);
         CommandSetting offsetPitch = new CommandSetting("offsetPitch", -1, Double.class, 0d);
         CommandSetting offsetDistance = new CommandSetting("offsetDistance", -1, Double.class, 0d);
+        CommandSetting limit = new CommandSetting("limit", -1, Integer.class, -1);
+        CommandSetting sort = new CommandSetting("sort", -1, String.class, "NEAREST");
         List<CommandSetting> settings = getSettings();
         settings.add(distance);
         settings.add(displayMsgIfNoPlayer);
@@ -40,6 +43,8 @@ public class Around extends MixedCommand {
         settings.add(offsetYaw);
         settings.add(offsetPitch);
         settings.add(offsetDistance);
+        settings.add(limit);
+        settings.add(sort);
         setNewSettingsMode(true);
         setCanExecuteCommands(true);
     }
@@ -56,6 +61,8 @@ public class Around extends MixedCommand {
                 double offsetYaw = (double) sCommandToExec.getSettingValue("offsetYaw");
                 double offsetPitch = (double) sCommandToExec.getSettingValue("offsetPitch");
                 double offsetDistance = (double) sCommandToExec.getSettingValue("offsetDistance");
+                int limit = (int) sCommandToExec.getSettingValue("limit");
+                String sort = (String) sCommandToExec.getSettingValue("sort");
 
                 Vector offset = XParticle.calculDirection(offsetYaw, offsetPitch).multiply(offsetDistance);
                 Location loc = receiver.getLocation().add(offset);
@@ -96,6 +103,20 @@ public class Around extends MixedCommand {
                         if (target.hasMetadata("NPC") || target.equals(receiver)) continue;
                         targets.add(target);
                     }
+                }
+
+                if (sort.equalsIgnoreCase("NEAREST")) {
+                    targets.sort((p1, p2) -> {
+                        double d1 = p1.getLocation().distance(loc);
+                        double d2 = p2.getLocation().distance(loc);
+                        return Double.compare(d1, d2);
+                    });
+                } else if (sort.equalsIgnoreCase("RANDOM")) {
+                    Collections.shuffle(targets);
+                }
+
+                if (limit > 0 && targets.size() > limit) {
+                    targets = targets.subList(0, limit);
                 }
 
                 boolean hit = CommmandThatRunsCommand.runPlayerCommands(targets, sCommandToExec.getOtherArgs(),sCommandToExec.getActionInfo());

--- a/src/main/java/com/ssomar/score/commands/runnable/mixed_player_entity/commands/HitscanEntities.java
+++ b/src/main/java/com/ssomar/score/commands/runnable/mixed_player_entity/commands/HitscanEntities.java
@@ -15,6 +15,7 @@ import org.bukkit.util.RayTraceResult;
 import org.bukkit.util.Vector;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -30,6 +31,8 @@ public class HitscanEntities extends MixedCommand {
         CommandSetting yShift = new CommandSetting("yShift", -1, Double.class, 0d);
         CommandSetting throughBlocks = new CommandSetting("throughBlocks", -1, Boolean.class, true);
         CommandSetting throughEntities = new CommandSetting("throughEntities", -1, Boolean.class, true);
+        CommandSetting limit = new CommandSetting("limit", -1, Integer.class, -1);
+        CommandSetting sort = new CommandSetting("sort", -1, String.class, "NEAREST");
         List<CommandSetting> settings = getSettings();
         settings.add(range);
         settings.add(radius);
@@ -39,6 +42,8 @@ public class HitscanEntities extends MixedCommand {
         settings.add(yShift);
         settings.add(throughEntities);
         settings.add(throughBlocks);
+        settings.add(limit);
+        settings.add(sort);
         setNewSettingsMode(true);
         setCanExecuteCommands(true);
     }
@@ -60,6 +65,8 @@ public class HitscanEntities extends MixedCommand {
         double yShift = (double) sCommandToExec.getSettingValue("yShift");
         boolean throughBlocks = (boolean) sCommandToExec.getSettingValue("throughBlocks");
         boolean throughEntities = (boolean) sCommandToExec.getSettingValue("throughEntities");
+        int limit = (int) sCommandToExec.getSettingValue("limit");
+        String sort = (String) sCommandToExec.getSettingValue("sort");
 
         if (receiver instanceof LivingEntity) {
 
@@ -102,6 +109,21 @@ public class HitscanEntities extends MixedCommand {
                 }
             }
         }
+
+        if (sort.equalsIgnoreCase("NEAREST")) {
+            entities.sort((e1, e2) -> {
+                double d1 = e1.getLocation().distance(receiver.getLocation());
+                double d2 = e2.getLocation().distance(receiver.getLocation());
+                return Double.compare(d1, d2);
+            });
+        } else if (sort.equalsIgnoreCase("RANDOM")) {
+            Collections.shuffle(entities);
+        }
+
+        if (limit > 0 && entities.size() > limit) {
+            entities = entities.subList(0, limit);
+        }
+
         return entities;
     }
 

--- a/src/main/java/com/ssomar/score/commands/runnable/mixed_player_entity/commands/HitscanPlayers.java
+++ b/src/main/java/com/ssomar/score/commands/runnable/mixed_player_entity/commands/HitscanPlayers.java
@@ -24,6 +24,8 @@ public class HitscanPlayers extends MixedCommand {
         CommandSetting yShift = new CommandSetting("yShift", -1, Double.class, 0d);
         CommandSetting throughBlocks = new CommandSetting("throughBlocks", -1, Boolean.class, true);
         CommandSetting throughEntities = new CommandSetting("throughEntities", -1, Boolean.class, true);
+        CommandSetting limit = new CommandSetting("limit", -1, Integer.class, -1);
+        CommandSetting sort = new CommandSetting("sort", -1, String.class, "NEAREST");
         List<CommandSetting> settings = getSettings();
         settings.add(range);
         settings.add(radius);
@@ -33,6 +35,8 @@ public class HitscanPlayers extends MixedCommand {
         settings.add(yShift);
         settings.add(throughEntities);
         settings.add(throughBlocks);
+        settings.add(limit);
+        settings.add(sort);
         setNewSettingsMode(true);
         setCanExecuteCommands(true);
     }

--- a/src/main/java/com/ssomar/score/commands/runnable/mixed_player_entity/commands/MobAround.java
+++ b/src/main/java/com/ssomar/score/commands/runnable/mixed_player_entity/commands/MobAround.java
@@ -28,6 +28,7 @@ import org.jetbrains.annotations.Nullable;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /* MOB_AROUND {distance} {Your commands here} */
@@ -42,6 +43,8 @@ public class MobAround extends MixedCommand implements FeatureParentInterface {
         CommandSetting offsetYaw = new CommandSetting("offsetYaw", -1, Double.class, 0d);
         CommandSetting offsetPitch = new CommandSetting("offsetPitch", -1, Double.class, 0d);
         CommandSetting offsetDistance = new CommandSetting("offsetDistance", -1, Double.class, 0d);
+        CommandSetting limit = new CommandSetting("limit", -1, Integer.class, -1);
+        CommandSetting sort = new CommandSetting("sort", -1, String.class, "NEAREST");
         List<CommandSetting> settings = getSettings();
         settings.add(distance);
         settings.add(displayMsgIfNoPlayer);
@@ -50,6 +53,8 @@ public class MobAround extends MixedCommand implements FeatureParentInterface {
         settings.add(offsetYaw);
         settings.add(offsetPitch);
         settings.add(offsetDistance);
+        settings.add(limit);
+        settings.add(sort);
         setNewSettingsMode(true);
         setCanExecuteCommands(true);
     }
@@ -69,6 +74,8 @@ public class MobAround extends MixedCommand implements FeatureParentInterface {
                     double offsetYaw = (double) sCommandToExec.getSettingValue("offsetYaw");
                     double offsetPitch = (double) sCommandToExec.getSettingValue("offsetPitch");
                     double offsetDistance = (double) sCommandToExec.getSettingValue("offsetDistance");
+                    int limit = (int) sCommandToExec.getSettingValue("limit");
+                    String sort = (String) sCommandToExec.getSettingValue("sort");
 
                     Vector offset = XParticle.calculDirection(offsetYaw, offsetPitch).multiply(offsetDistance);
 
@@ -117,6 +124,20 @@ public class MobAround extends MixedCommand implements FeatureParentInterface {
                             if (target.hasMetadata("NPC") || target.equals(receiver)) continue;
                             entities.add(target);
                         }
+                    }
+
+                    if (sort.equalsIgnoreCase("NEAREST")) {
+                        entities.sort((e1, e2) -> {
+                            double d1 = e1.getLocation().distance(receiverLoc);
+                            double d2 = e2.getLocation().distance(receiverLoc);
+                            return Double.compare(d1, d2);
+                        });
+                    } else if (sort.equalsIgnoreCase("RANDOM")) {
+                        Collections.shuffle(entities);
+                    }
+
+                    if (limit > 0 && entities.size() > limit) {
+                        entities = entities.subList(0, limit);
                     }
 
                     boolean hit = CommmandThatRunsCommand.runEntityCommands(entities, sCommandToExec.getOtherArgs(), sCommandToExec.getActionInfo());


### PR DESCRIPTION
This pull request adds the ability to limit the number of entities targeted and sort them by proximity or randomly for the AROUND, MOB_AROUND, HITSCAN, and HITSCAN_PLAYERS commands.