### PR TITLE
fix: Resolve database connection and SQLite syntax errors

### DIFF
--- a/src/main/java/com/ssomar/score/data/Database1v18.java
+++ b/src/main/java/com/ssomar/score/data/Database1v18.java
@@ -19,6 +19,7 @@ public class Database1v18 {
         dataSource.setServerTimezone("UTC");
         dataSource.setUseSSL(false);
         dataSource.setAutoReconnect(true);
+        dataSource.setAllowPublicKeyRetrieval(true);
         return dataSource.getConnection();
     }
 }

--- a/src/main/java/com/ssomar/score/data/DatabaseOld.java
+++ b/src/main/java/com/ssomar/score/data/DatabaseOld.java
@@ -20,6 +20,7 @@ public class DatabaseOld {
         dataSource.setServerTimezone("UTC");
         dataSource.setUseSSL(false);
         dataSource.setAutoReconnect(true);
+        dataSource.setAllowPublicKeyRetrieval(true);
         return dataSource.getConnection();
     }
 }

--- a/src/main/java/com/ssomar/score/data/VariablesQuery.java
+++ b/src/main/java/com/ssomar/score/data/VariablesQuery.java
@@ -32,9 +32,13 @@ public class VariablesQuery {
         try  {
             stmt = conn.createStatement();
             Utils.sendConsoleMsg(SCore.NAME_COLOR + " &7Creating table &6" + TABLE_VARIABLES_NAME + " &7if not exists...");
-            if(Database.useMySQL) stmt.execute(CREATE_TABLE_SQL);
-            else stmt.execute(CREATE_TABLE_SQLITE);
-            stmt.execute(UPDATE_TABLE);
+            if(Database.useMySQL) {
+                stmt.execute(CREATE_TABLE_SQL);
+                // Only execute UPDATE_TABLE for MySQL as it uses MySQL-specific MODIFY syntax
+                stmt.execute(UPDATE_TABLE);
+            } else {
+                stmt.execute(CREATE_TABLE_SQLITE);
+            }
         } catch (SQLException e) {
             SCore.plugin.getLogger().severe("Error while creating table " + TABLE_VARIABLES_NAME + " in database "+e.getMessage());
         }


### PR DESCRIPTION
## Summary

This PR fixes critical database errors that were causing startup failures and connection issues in SCore:

1. **SQLite MODIFY syntax error** - Fixed MySQL-specific syntax being executed on SQLite
2. **MySQL connection failures** - Added missing `allowPublicKeyRetrieval=true` parameter

## Issues Resolved

### Error 1: SQLite MODIFY Syntax Error
```
[SQLITE_ERROR] SQL error or missing database (near "MODIFY": syntax error)
```

**Root Cause**: `VariablesQuery.createNewTable()` was executing a MySQL-specific `ALTER TABLE ... MODIFY` statement on SQLite databases.

**Fix**: Added conditional check to only execute `UPDATE_TABLE` statement for MySQL databases:
```java
if(Database.useMySQL) {
    stmt.execute(CREATE_TABLE_SQL);
    // Only execute UPDATE_TABLE for MySQL as it uses MySQL-specific MODIFY syntax
    stmt.execute(UPDATE_TABLE);
} else {
    stmt.execute(CREATE_TABLE_SQLITE);
}
```

### Error 2: MySQL Connection Failures
```
Could not create connection to database server. Attempted reconnect 3 times. Giving up.
```

**Root Cause**: Missing `allowPublicKeyRetrieval=true` parameter required for modern MySQL 8.0+ connections.

**Fix**: Added the parameter to both database connection classes:
- `Database1v18.java`: Added `dataSource.setAllowPublicKeyRetrieval(true);`
- `DatabaseOld.java`: Added `dataSource.setAllowPublicKeyRetrieval(true);`

## Files Modified

### `/src/main/java/com/ssomar/score/data/VariablesQuery.java`
- **Line 35-41**: Added conditional MySQL check for `UPDATE_TABLE` execution
- **Reasoning**: SQLite doesn't support `MODIFY` syntax in `ALTER TABLE` statements

### `/src/main/java/com/ssomar/score/data/Database1v18.java`
- **Line 22**: Added `dataSource.setAllowPublicKeyRetrieval(true);`
- **Reasoning**: Required for MySQL 8.0+ connections with public key retrieval

### `/src/main/java/com/ssomar/score/data/DatabaseOld.java`
- **Line 23**: Added `dataSource.setAllowPublicKeyRetrieval(true);`
- **Reasoning**: Consistent configuration across all MySQL connection classes

## Technical Details

### SQLite vs MySQL Compatibility
The original code violated database-specific syntax rules:
- **MySQL**: Supports `ALTER TABLE table MODIFY column datatype`
- **SQLite**: Does not support `MODIFY` keyword in `ALTER TABLE`

### MySQL Connection Parameters
Modern MySQL connections often require additional security parameters:
- `allowPublicKeyRetrieval=true` - Allows retrieval of public keys from server
- Essential for authentication with caching_sha2_password (default in MySQL 8.0+)

## Impact

### Before Fix
- Plugin startup failures due to Variables table creation errors
- MySQL connection timeouts and authentication failures
- Fallback to SQLite with corrupted table structures

### After Fix
- Clean database initialization for both MySQL and SQLite
- Reliable MySQL connections with proper authentication
- Consistent database behavior across different server configurations

## Testing

- [x] Verified SQLite table creation works without MODIFY syntax
- [x] Confirmed MySQL connections succeed with allowPublicKeyRetrieval
- [x] Tested database fallback mechanism remains functional
- [x] Validated Variables table structure consistency

## Backward Compatibility

✅ **Fully backward compatible**
- No breaking changes to existing database schemas
- No changes to public APIs or configuration files
- Safe to deploy on existing installations

🤖 Generated with [Claude Code](https://claude.ai/code)