### PR TITLE
patched bugs on certain edge cases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,38 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>Special70</id>
+            <build>
+            <finalName>${project.artifactId}-${project.version}</finalName>
+            <plugins>
+                <!-- Maven AntRun Plugin to copy the JAR to a specific location -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-antrun-plugin</artifactId>
+                    <version>3.1.0</version> <!-- Add the version for clarity -->
+                    <executions>
+                        <execution>
+                            <phase>install</phase>
+                            <goals>
+                                <goal>run</goal>
+                            </goals>
+                            <configuration>
+                                <target>
+                                    <copy file="${project.build.directory}/${project.artifactId}-${project.version}.jar"
+                                          tofile="E:\Razer\Documents\GitHub\ExecutableItems\src\main\resources\SCore.jar"/>
+                                    <copy file="${project.build.directory}/${project.artifactId}-${project.version}.jar"
+                                          tofile="E:\Razer\Documents\Server Files\PAPERSPIGOT 1.21.4\plugins\SCore.jar"/>
+                                </target>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+
+            </plugins>
+            </build>
+
+        </profile>
     </profiles>
 
     <repositories>

--- a/src/main/java/com/ssomar/score/commands/runnable/mixed_player_entity/commands/AddTemporaryAttribute.java
+++ b/src/main/java/com/ssomar/score/commands/runnable/mixed_player_entity/commands/AddTemporaryAttribute.java
@@ -15,14 +15,19 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitTask;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 /**
  * When used, it gives the target player/entity a given attribute for a set period of time.
  * The attribute provided by this custom command does not set the value, but gives a modifier.
+ * <br>
+ * Checks needed before publishing updates: <br>
+ * - Living entities must work properly with it.<br>
+ * - If the living entity is a player and the player logged off, it should be stored in a variable then use PlayerJoinEvent to try to attempt removal once more.<br>
+ *  - It should not face issues if multiple similar attributes are inserted.<br>
+ * - If a non-living entity (arrows for example) was attempted to be given temporary attributes via this custom command, nothing should happen.
  */
 public class AddTemporaryAttribute extends MixedCommand  {
 
@@ -63,7 +68,11 @@ public class AddTemporaryAttribute extends MixedCommand  {
     }
 
     @Override
-    public void run(Player p, Entity entity, SCommandToExec sCommandToExec) {
+    public void run(Player p, Entity entityTarget, SCommandToExec sCommandToExec) {
+
+        // this custom command should only work for LivingEntity entities
+        if (!(entityTarget instanceof LivingEntity)) return;
+
         // arg0: attribute
         // arg1: amount
         // arg2: operation
@@ -71,9 +80,9 @@ public class AddTemporaryAttribute extends MixedCommand  {
         // arg3: timeinticks
 
         // invalid attribute checker
-        Attribute attrCheck = AttributeUtils.getAttribute((String) sCommandToExec.getSettingValue("attribute"));
+        Attribute attribute = AttributeUtils.getAttribute((String) sCommandToExec.getSettingValue("attribute"));
 
-        if (attrCheck == null) {
+        if (attribute == null) {
             SCore.plugin.getLogger().info("[ADD_TEMPORARY_ATTRIBUTE] Invalid Attribute argument was provided for field attribute: "+sCommandToExec.getSettingValue("attribute"));
             return;
         }
@@ -113,28 +122,115 @@ public class AddTemporaryAttribute extends MixedCommand  {
         }
 
 
-        AttributeInstance attrInstance = null;
-
-        // the entity arg in the method arguments refer to the target of the command and the player arg represents the caster.
-        // if the target is a Player, cast the entity as a player.
-        if (entity instanceof LivingEntity) {
-            LivingEntity livingEntity = (LivingEntity) entity;
-            attrInstance = livingEntity.getAttribute((attrCheck));
-        }
+        AttributeInstance attrInstance = ((LivingEntity) entityTarget).getAttribute((attribute));
 
         // make a randomized key to allow spamming of ADD_TEMPORARY_ATTRIBUTE
         NamespacedKey key = new NamespacedKey(SCore.plugin, "mod_" + UUID.randomUUID());
         AttributeModifier tempModifier = new AttributeModifier(key, Double.parseDouble(sCommandToExec.getSettingValue("amount").toString()), operation);
 
+        if (entityTarget instanceof Player) {
+            if (!tempModifiers.containsKey(entityTarget.getUniqueId()))
+                tempModifiers.put(entityTarget.getUniqueId(), new HashMap<>());
+
+            final HashMap<Attribute, HashMap<NamespacedKey, Long>> entityTempAttr = tempModifiers.get(entityTarget.getUniqueId());
+
+            if (!entityTempAttr.containsKey(attribute))
+                tempModifiers.get(entityTarget.getUniqueId()).put(attribute, new HashMap<>());
+
+            tempModifiers.get(entityTarget.getUniqueId()).get(attribute).put(key, System.currentTimeMillis() + Long.parseLong(sCommandToExec.getSettingValue("timeinticks").toString()) * 50);
+        }
+
         attrInstance.addModifier(tempModifier);
 
-        AttributeInstance finalAttrInstance = attrInstance;
         new BukkitRunnable() {
             @Override
             public void run() {
-                finalAttrInstance.removeModifier(tempModifier);
+                if (tempModifiers.get(entityTarget.getUniqueId()).get(attribute).containsKey(key)) {
+                    if (entityTarget instanceof Player) {
+                        if (((Player) entityTarget).isOnline()) {
+                            attemptToRemoveModifier((Player) entityTarget);
+                        }
+                    } else {
+                        // ingame entities are less problematic
+                        ((LivingEntity) entityTarget).getAttribute(attribute).removeModifier(((LivingEntity) entityTarget).getAttribute(attribute).getModifier(key));
+                    }
+                }
             }
         }.runTaskLater(SCore.plugin, Long.parseLong(sCommandToExec.getSettingValue("timeinticks").toString()));
+    }
+
+    /**
+     * Stores ongoing running bukkit tasks to prevent duplicates
+     */
+    private static final Set<NamespacedKey> scheduledKeyRemovals = new HashSet<>();
+    /**<pre>
+     * UUID - Stores the player's uuid
+     *      Attribute - Stores the Attribute enum to organize temp attribute types
+     *          Namespacedkey - a pointer/reference to the temp attribute (mainly for being able to grab its pointer again despite the relogs)
+     *          Long - time till expiration in milliseconds</pre>
+     */
+    public static HashMap<UUID, HashMap<Attribute, HashMap<NamespacedKey, Long>>> tempModifiers = new HashMap<>();
+
+    /**
+     * Attempts to remove expired temporary attributes
+     * @param player - the player who has the temporary attributes
+     * @param ignoreTimeGap - mainly for the BukkitRunnable to rely on their timers. Reasons is that there has been issues where the System.currentTimeMillis() does not properly match up with
+     *                      BukkitRunnable delay (some tests have observed 35 tick delays)
+     */
+    public static void attemptToRemoveModifier(Player player) {
+        /**
+         * L0 = HashMap<UUID, L1>
+         * L1 = HashMap<Attribute, HashMap<Namespacedkey, Long>>
+         * Had to write this because my brain is overloading just thinking about this nested hashmaps
+         */
+        Iterator<Map.Entry<Attribute, HashMap<NamespacedKey, Long>>> attrIterator = tempModifiers.get(player.getUniqueId()).entrySet().iterator();
+        while (attrIterator.hasNext()) {
+            Map.Entry<Attribute, HashMap<NamespacedKey, Long>> tempModifiers_attr_hashmap = attrIterator.next();
+            AttributeInstance attributeInstance = player.getAttribute(tempModifiers_attr_hashmap.getKey());
+            if (attributeInstance == null) {
+                return;
+            }
+            for (AttributeModifier attributeModifier : attributeInstance.getModifiers()) {
+                NamespacedKey namespacedkey = attributeModifier.getKey();
+                if (tempModifiers_attr_hashmap.getValue().containsKey(namespacedkey) && !scheduledKeyRemovals.contains(namespacedkey)) {
+                    scheduledKeyRemovals.add(namespacedkey);
+                    new BukkitRunnable() {
+                        @Override
+                        public void run() {
+                            // attempt to remove modifier
+                            if (player.isOnline()) {
+                                attributeInstance.removeModifier(attributeModifier.getKey());
+                                tempModifiers_attr_hashmap.getValue().remove(attributeModifier.getKey());
+
+                                cleanRecords(player, tempModifiers_attr_hashmap);
+                            }
+                            scheduledKeyRemovals.remove(namespacedkey);
+                        }
+                    }.runTaskLater(SCore.plugin,Math.max(0, (tempModifiers_attr_hashmap.getValue().get(namespacedkey) - System.currentTimeMillis()) / 50));
+                }
+
+
+
+            }
+            cleanRecords(player, tempModifiers_attr_hashmap);
+        }
+    }
+
+    /**
+     * Attempts to clean hashmap records if the hash value isn't in use anymore.
+     * @param player
+     * @param tempModifiers_attr_hashmap
+     */
+    private static void cleanRecords(Player player, Map.Entry<Attribute, HashMap<NamespacedKey, Long>> tempModifiers_attr_hashmap) {
+        if (!tempModifiers.containsKey(player.getUniqueId())) return;
+        // remove empty classes
+        if (tempModifiers.get(player.getUniqueId()).get(tempModifiers_attr_hashmap.getKey()).isEmpty()) {
+            tempModifiers.get(player.getUniqueId()).remove(tempModifiers_attr_hashmap.getKey());
+        }
+        // remove the value when it's not needed anymore.
+        if (tempModifiers.get(player.getUniqueId()).isEmpty()) {
+            tempModifiers.remove(player.getUniqueId());
+        }
     }
 
 }

--- a/src/main/java/com/ssomar/score/events/PlayerJoinListener.java
+++ b/src/main/java/com/ssomar/score/events/PlayerJoinListener.java
@@ -1,5 +1,7 @@
 package com.ssomar.score.events;
 
+import com.ssomar.score.SCore;
+import com.ssomar.score.commands.runnable.mixed_player_entity.commands.AddTemporaryAttribute;
 import com.ssomar.score.commands.runnable.player.commands.absorption.AbsorptionManager;
 import com.ssomar.score.commands.runnable.player.commands.sudoop.SUDOOPManager;
 import com.ssomar.score.data.Database;
@@ -10,12 +12,26 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import static com.ssomar.score.commands.runnable.mixed_player_entity.commands.AddTemporaryAttribute.tempModifiers;
 
 public class PlayerJoinListener implements Listener {
 
 
     @EventHandler(priority = EventPriority.HIGH)
     public void playerReconnexion(PlayerJoinEvent e) {
+
+        // attempts to remove
+        if (tempModifiers.containsKey(e.getPlayer().getUniqueId()))  {
+            new BukkitRunnable() {
+                @Override
+                public void run() {
+                    AddTemporaryAttribute.attemptToRemoveModifier(e.getPlayer());
+                }
+            }.runTaskAsynchronously(SCore.plugin);
+        }
+
         Player p = e.getPlayer();
 
         if (SUDOOPManager.getInstance().getPlayersThatMustBeDeOP().contains(p.getUniqueId())) {


### PR DESCRIPTION
- Added a profile for my personal use
- Made the custom command stop asap if the target entity is not a LivingEntity (despite the probable performance increase being negligible, I want to practice this habit)
- Renamed some attributes for better understanding
- Refactored code related to getting the target's attributes
- Reworked the logic for providing temporary attributes so it doesn't bug out if the temp attribute expires during logout and during relog