### PR TITLE
Attempt to fix the database

### DIFF
--- a/src/main/java/com/ssomar/score/data/Database.java
+++ b/src/main/java/com/ssomar/score/data/Database.java
@@ -75,9 +75,11 @@ public class Database {
         }
         String urlLocal = "jdbc:sqlite:" + SCore.dataFolder + "/" + fileName;
 
-        boolean needOpenConnection;
+        boolean needOpenConnection = true;
         try {
-            needOpenConnection = conn == null || conn.isClosed();
+            if (conn != null && !conn.isClosed() && conn.isValid(2)) {
+                needOpenConnection = false;
+            }
         } catch (SQLException e) {
             needOpenConnection = true;
         }


### PR DESCRIPTION
Attempt to fix this error:
[SCore] Error while selecting variable in database The last packet successfully received from the server was 36,344,205 milliseconds ago. The last packet sent successfully to the server was 36,344,205 milliseconds ago. is longer than the server configured value of 'wait_timeout'. You should consider either expiring and/or testing connection validity before use in your application, increasing the server configured values for client timeouts, or using the Connector/J connection property 'autoReconnect=true' to avoid this problem.