### PR TITLE
Added if entity in region condition and fawe soft depend checker

### DIFF
--- a/src/main/java/com/ssomar/score/SCore.java
+++ b/src/main/java/com/ssomar/score/SCore.java
@@ -103,6 +103,7 @@ public final class SCore extends JavaPlugin implements SPlugin {
     public static boolean hasShopGUIPlus = false;
     public static boolean hasRoseLoot = false;
     public static boolean hasCustomFishing = false;
+    public static boolean hasFastAsyncWorldEdit = false;
 
     public static boolean hasRoseStacker = false;
     public static boolean hasMMOCore = false;
@@ -614,6 +615,8 @@ public final class SCore extends JavaPlugin implements SPlugin {
         hasCoreProtect = Dependency.CORE_PROTECT.hookSoftDependency();
 
         hasFactionsUUID = Dependency.FACTIONS_UUID.hookSoftDependency();
+
+        hasFastAsyncWorldEdit = Dependency.FAST_ASYNC_WORLD_EDIT.hookSoftDependency();
 
         Dependency.PACKET_EVENTS.hookSoftDependency();
 

--- a/src/main/java/com/ssomar/score/features/FeatureSettingsSCore.java
+++ b/src/main/java/com/ssomar/score/features/FeatureSettingsSCore.java
@@ -171,6 +171,7 @@ public enum FeatureSettingsSCore implements FeatureSettingsInterface {
     ifDurability(getFeatureSettings("ifDurability", SavingVerbosityLevel.SAVE_ONLY_WHEN_DIFFERENT_DEFAULT)),
     ifUseCooldown(getFeatureSettings("ifUseCooldown", SavingVerbosityLevel.SAVE_ONLY_WHEN_DIFFERENT_DEFAULT)),
     ifEntityHealth(getFeatureSettings("ifEntityHealth", SavingVerbosityLevel.SAVE_ONLY_WHEN_DIFFERENT_DEFAULT)),
+    ifEntityInRegion(getFeatureSettings("ifEntityInRegion",SavingVerbosityLevel.SAVE_ONLY_WHEN_DIFFERENT_DEFAULT)),
     ifFlying(getFeatureSettings("ifFlying", SavingVerbosityLevel.SAVE_ONLY_WHEN_DIFFERENT_DEFAULT)),
     ifFromSpawner(getFeatureSettings("ifFromSpawner", SavingVerbosityLevel.SAVE_ONLY_WHEN_DIFFERENT_DEFAULT)),
     ifFrozen(getFeatureSettings("ifFrozen", SavingVerbosityLevel.SAVE_ONLY_WHEN_DIFFERENT_DEFAULT)),

--- a/src/main/java/com/ssomar/score/features/custom/conditions/entity/condition/IfEntityInRegion.java
+++ b/src/main/java/com/ssomar/score/features/custom/conditions/entity/condition/IfEntityInRegion.java
@@ -1,0 +1,73 @@
+package com.ssomar.score.features.custom.conditions.entity.condition;
+
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldedit.util.Location;
+import com.sk89q.worldguard.WorldGuard;
+import com.sk89q.worldguard.protection.ApplicableRegionSet;
+import com.sk89q.worldguard.protection.managers.RegionManager;
+import com.sk89q.worldguard.protection.regions.ProtectedRegion;
+import com.sk89q.worldguard.protection.regions.RegionContainer;
+import com.ssomar.score.SCore;
+import com.ssomar.score.features.FeatureParentInterface;
+import com.ssomar.score.features.FeatureSettingsSCore;
+import com.ssomar.score.features.custom.conditions.entity.EntityConditionFeature;
+import com.ssomar.score.features.custom.conditions.entity.EntityConditionRequest;
+import com.ssomar.score.features.types.list.ListUncoloredStringFeature;
+import org.bukkit.entity.Entity;
+
+import java.util.ArrayList;
+import java.util.Optional;
+
+public class IfEntityInRegion extends EntityConditionFeature<ListUncoloredStringFeature, IfEntityInRegion> {
+    public IfEntityInRegion(FeatureParentInterface parent) {
+        super(parent, FeatureSettingsSCore.ifEntityInRegion);
+    }
+
+    @Override
+    public boolean verifCondition(EntityConditionRequest request) {
+        if (hasCondition()) {
+
+            if (SCore.hasWorldEdit || SCore.hasFastAsyncWorldEdit) {
+                Entity entity = request.getEntity();
+                Location loc = BukkitAdapter.adapt(entity.getLocation());
+                RegionContainer container = WorldGuard.getInstance().getPlatform().getRegionContainer();
+                RegionManager regions = container.get(BukkitAdapter.adapt(entity.getWorld()));
+
+                if (regions == null) return false;
+
+                ApplicableRegionSet set = regions.getApplicableRegions(loc.toVector().toBlockPoint());
+
+                for (String name : getCondition().getValue(request.getSp())) {
+                    for (ProtectedRegion region : set) {
+                        if (region.getId().equalsIgnoreCase(name)) {
+                            return true;
+                        }
+                    }
+                }
+            }
+            return false;
+
+
+        } else return false;
+    }
+
+    @Override
+    public void subReset() {
+        setCondition(new ListUncoloredStringFeature(getParent(), new ArrayList<>(), FeatureSettingsSCore.ifEntityInRegion, Optional.empty()));
+    }
+
+    @Override
+    public boolean hasCondition() {
+        return !getCondition().getValue().isEmpty();
+    }
+
+    @Override
+    public IfEntityInRegion getNewInstance(FeatureParentInterface newParent) {
+        return new IfEntityInRegion(newParent);
+    }
+
+    @Override
+    public IfEntityInRegion getValue() {
+        return this;
+    }
+}

--- a/src/main/java/com/ssomar/score/features/custom/conditions/entity/parent/EntityConditionsFeature.java
+++ b/src/main/java/com/ssomar/score/features/custom/conditions/entity/parent/EntityConditionsFeature.java
@@ -73,6 +73,7 @@ public class EntityConditionsFeature extends FeatureWithHisOwnEditor<EntityCondi
         conditions.add(new IfHasTag(this));
         conditions.add(new IfNotHasTag(this));
         conditions.add(new IfSheepColor(this));
+        conditions.add(new IfEntityInRegion(this));
 
         /* List Material with tags */
         conditions.add(new IfIsOnTheBlock(this));

--- a/src/main/java/com/ssomar/score/features/lang/FeatureSettingsSCoreEN.java
+++ b/src/main/java/com/ssomar/score/features/lang/FeatureSettingsSCoreEN.java
@@ -649,6 +649,7 @@ public enum FeatureSettingsSCoreEN implements FeatureSettingsInterface {
     itemTextures("itemTextures", "Item Textures", new String[]{"&7&oThe item textures"}, FixedMaterial.getMaterial(Arrays.asList("BLUE_GLAZED_TERRACOTTA"))),
     itemAdvancedComponents("itemAdvancedComponents", "Item Advanced Components", new String[]{"&7&oThe item advanced components"}, Material.ARMOR_STAND),
     ifGameMode("ifGameMode", "If Game Mode", new String[]{"&7&oIf the game mode is"}, Material.ANVIL),
+    ifEntityInRegion("ifEntityInRegion", "If entity is in region", new String[]{}, Material.ANVIL)
     ;
 
 

--- a/src/main/java/com/ssomar/score/usedapi/Dependency.java
+++ b/src/main/java/com/ssomar/score/usedapi/Dependency.java
@@ -108,7 +108,9 @@ public enum Dependency {
 
     WORLD_EDIT("WorldEdit"),
 
-    CUSTOM_FISHING("CustomFishing");
+    CUSTOM_FISHING("CustomFishing"),
+
+    FAST_ASYNC_WORLD_EDIT("FastAsyncWorldEdit");
 
     private final String name;
 


### PR DESCRIPTION
- Added FastAsyncWorldEdit plugin check (except pom.xml dependency because I don't need it) for Worldguard requires either WorldEdit or FAWE but there can be chances where servers use FAWE instead of WorldEdit
- Added an entity condition called "IfEntityInRegion" that checks if the entity is in a specific worldguard region