### PR TITLE
Added a setTarget() method call if the projectile is a ShulkerBullet

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,6 +222,8 @@
                                               tofile="E:\Razer\Documents\GitHub\ExecutableItems\src\main\resources\SCore.jar"/>
                                         <copy file="${project.build.directory}/${project.artifactId}-${project.version}.jar"
                                               tofile="E:\Razer\Documents\Server Files\PAPERSPIGOT 1.21.4\plugins\SCore.jar"/>
+                                        <copy file="${project.build.directory}/${project.artifactId}-${project.version}.jar"
+                                              tofile="E:\Razer\Documents\Server Files\PAPERSPIGOT 1.21.6\plugins\SCore.jar"/>
                                     </target>
                                 </configuration>
                             </execution>

--- a/src/main/java/com/ssomar/score/commands/runnable/player/commands/Launch.java
+++ b/src/main/java/com/ssomar/score/commands/runnable/player/commands/Launch.java
@@ -71,6 +71,12 @@ public class Launch extends PlayerCommand {
                         entity = receiver.launchProjectile(SProjectileType.getProjectilesClasses().get(projectile.getType().getValue().get().getValidNames()[0]));
                     } else entity = receiver.launchProjectile(Arrow.class);
 
+                    // for some reason, starting at 1.21.6, minecraft does a NullPointerException if projectiles like shulkerbullet does not have a target
+                    if (entity instanceof ShulkerBullet) {
+                        ShulkerBullet bullet = (ShulkerBullet) entity;
+                        bullet.setTarget(null);
+                    }
+
                     if (entity instanceof Firework) {
                         entity.remove();
                         EntityType fireworkType =  SCore.is1v20v5Plus() ? EntityType.FIREWORK_ROCKET : EntityType.valueOf("FIREWORK");


### PR DESCRIPTION
for some reason, starting at 1.21.6, minecraft does a NullPointerException if projectiles like shulkerbullet does not have a target