### PR TITLE
Fixed an issue with BREAK not properly removing ExecutableBlocks

### DIFF
--- a/src/main/java/com/ssomar/score/usedapi/ItemsAdderAPI.java
+++ b/src/main/java/com/ssomar/score/usedapi/ItemsAdderAPI.java
@@ -1,9 +1,11 @@
 package com.ssomar.score.usedapi;
 
 import com.ssomar.score.SCore;
+import com.ssomar.score.SsomarDev;
 import dev.lone.itemsadder.api.CustomBlock;
 import dev.lone.itemsadder.api.CustomFurniture;
 import dev.lone.itemsadder.api.CustomStack;
+import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.entity.ArmorStand;
@@ -13,15 +15,20 @@ import org.bukkit.inventory.ItemStack;
 import java.util.List;
 import java.util.Optional;
 
+import static com.ssomar.score.utils.safebreak.SafeBreak.breakEB;
+
 public class ItemsAdderAPI {
 
     public static boolean breakCustomBlock(Block block, ItemStack item, boolean drop) {
+        SsomarDev.testMsg(ChatColor.GOLD+"[#s0003] breakCustomBlock() method call from ItemsAdderAPI.java", true);
         if (SCore.hasItemsAdder && block != null && !block.isEmpty()) {
             // https://discord.com/channels/701066025516531753/1386807735009677493 remove for custom IA build
             if (SCore.hasClass("dev.lone.itemsadder.api.CustomBlock")) {
+                SsomarDev.testMsg("[#s0004] Attempted to break ItemsAdder block", true);
                 CustomBlock customBlock = CustomBlock.byAlreadyPlaced(block);
                 //SsomarDev.testMsg("ITEM ADDER DETECTED >> "+(customBlock != null), true);
                 if (customBlock != null) {
+                    SsomarDev.testMsg("[#s0005] Custom Block is not null", true);
                     //SsomarDev.testMsg("ITEM ADDER REMOVED", true);
                     if (drop) {
                         List<ItemStack> loots = customBlock.getLoot(item, false);
@@ -45,12 +52,23 @@ public class ItemsAdderAPI {
             ArmorStand armorStand;
             for (Entity e : block.getLocation().getWorld().getNearbyEntities(block.getLocation(), 0.5, 0.5, 0.5)) {
                 if (e instanceof ArmorStand) {
+                    SsomarDev.testMsg("[#s0006] Custom Block instanceof ArmorStanmd", true);
                     armorStand = (ArmorStand) e;
                     //SsomarDev.testMsg("ITEM ADDER DETECTED >> "+armorStand.getCustomName(), true);
                     if (armorStand.getCustomName() != null && armorStand.getCustomName().equals("ItemsAdder_furniture")) {
+                        SsomarDev.testMsg("[#s0007] Armorstand has a name and ArmorStand name is \"ItemsAdder_furniture\"", true);
                         CustomFurniture furniture = CustomFurniture.byAlreadySpawned(armorStand);
                         furniture.remove(drop);
+                        // to patch an issue where BREAK doesn't remove the EB-ItemsAdder block
+                        // its drop arg is set to false because when you use BREAK on an EB, it already drops the loot.
+                        breakEB(null, block, false);
                         return true;
+                    } else {
+                        if (armorStand.getCustomName() == null) {
+                            SsomarDev.testMsg("[#s0008] Armorstand has no name", true);
+                        } else {
+                            SsomarDev.testMsg("[#s0009] Armorstand is not IA; name is: " + armorStand.getCustomName(), true);
+                        }
                     }
                 }
             }

--- a/src/main/java/com/ssomar/score/utils/safebreak/SafeBreak.java
+++ b/src/main/java/com/ssomar/score/utils/safebreak/SafeBreak.java
@@ -14,6 +14,7 @@ import dev.rosewood.roseloot.loot.context.LootContextParams;
 import dev.rosewood.roseloot.loot.table.LootTableTypes;
 import dev.rosewood.roseloot.manager.LootTableManager;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -37,18 +38,23 @@ public class SafeBreak {
     /* return false its verifSafeBreak is false */
     public static boolean breakBlockWithEvent(final Block block, @Nullable final UUID playerUUID, int slot, boolean drop, boolean generateBreakEvent, boolean verifSafeBreak, BlockBreakEventExtension.BreakCause breakCause) {
 
-        SsomarDev.testMsg("DEBUG SAFE BREAK 1", DEBUG);
+        SsomarDev.testMsg(ChatColor.GOLD+"[#s0010] breakBlockWithEvent() trigger from SafeBreak.java", DEBUG);
         if (playerUUID == null) {
+            SsomarDev.testMsg("[#s0013] Player is null", DEBUG);
             if (breakEB(null, block, drop)) return true;
             block.breakNaturally();
             return true;
         }
-        SsomarDev.testMsg("DEBUG SAFE BREAK 1.5", DEBUG);
+        SsomarDev.testMsg("[#s0011] Player is not null", DEBUG);
 
         Player player = Bukkit.getServer().getPlayer(playerUUID);
 
-        SsomarDev.testMsg("DEBUG SAFE BREAK 1.6 p: "+player, DEBUG);
+        SsomarDev.testMsg("[#s0012] Safely obtained player instance : "+player, DEBUG);
 
+        // if player is
+        // - not null
+        // - is opped
+        // then continue on. else,
         if(!(player != null && player.isOp())){
             if (verifSafeBreak && !verifSafeBreak(playerUUID, block)){
                 SsomarDev.testMsg("DEBUG SAFE BREAK VERIFICATION BLOCKED ", DEBUG);


### PR DESCRIPTION
- The issue with the logic is that breakEB() isn't called when the ItemsAdder blocks is detected as an ArmorStand
- Added & Modified debug messages for documentation's sake