### PR TITLE
Fix/shulkerbullet no such method

### DIFF
--- a/src/main/java/com/ssomar/score/commands/runnable/player/commands/Launch.java
+++ b/src/main/java/com/ssomar/score/commands/runnable/player/commands/Launch.java
@@ -3,6 +3,7 @@ package com.ssomar.score.commands.runnable.player.commands;
 import com.ssomar.executableitems.listeners.projectiles.ProjectileInfo;
 import com.ssomar.executableitems.listeners.projectiles.ProjectilesHandler;
 import com.ssomar.score.SCore;
+import com.ssomar.score.SsomarDev;
 import com.ssomar.score.commands.runnable.CommandSetting;
 import com.ssomar.score.commands.runnable.SCommandToExec;
 import com.ssomar.score.commands.runnable.player.PlayerCommand;
@@ -73,13 +74,13 @@ public class Launch extends PlayerCommand {
 
                     // for some reason, starting at 1.21.6, minecraft does a NullPointerException if projectiles like shulkerbullet does not have a target
                     try {
-                        Class<?> shulkerBulletClass = Class.forName("org.bukkit.entity.ShulkerBullet");
-                        if (shulkerBulletClass.isInstance(entity) && SCore.is1v21v6Plus()) {
-                            Object bullet = shulkerBulletClass.cast(entity);
-                            shulkerBulletClass.getMethod("setTarget", LivingEntity.class).invoke(bullet, (LivingEntity) null);
+                        if (entity instanceof ShulkerBullet && SCore.is1v21v6Plus()) {
+                            ShulkerBullet bullet = (ShulkerBullet) entity;
+                            bullet.setTarget(null);
+                            //shulkerBulletClass.getMethod("setTarget", LivingEntity.class).invoke(bullet, (LivingEntity) null);
                         }
-                    } catch (ClassNotFoundException ignored) {
-                        // ShulkerBullet doesn't exist in this version (1.8
+                    } catch (Exception e) {
+                        entity = receiver.launchProjectile(Arrow.class);
                     }
 
                     if (entity instanceof Firework) {

--- a/src/main/java/com/ssomar/score/commands/runnable/player/commands/Launch.java
+++ b/src/main/java/com/ssomar/score/commands/runnable/player/commands/Launch.java
@@ -72,10 +72,9 @@ public class Launch extends PlayerCommand {
                     } else entity = receiver.launchProjectile(Arrow.class);
 
                     // for some reason, starting at 1.21.6, minecraft does a NullPointerException if projectiles like shulkerbullet does not have a target
-
                     try {
                         Class<?> shulkerBulletClass = Class.forName("org.bukkit.entity.ShulkerBullet");
-                        if (shulkerBulletClass.isInstance(entity)) {
+                        if (shulkerBulletClass.isInstance(entity) && SCore.is1v21v6Plus()) {
                             Object bullet = shulkerBulletClass.cast(entity);
                             shulkerBulletClass.getMethod("setTarget", LivingEntity.class).invoke(bullet, (LivingEntity) null);
                         }


### PR DESCRIPTION
Changed the logic from checking if such class exists into a downcast and made the try catch launch an arrow instead if it was used in 1.8