### PR TITLE
fix: add FALLING_DUST to block-data particle list

### DIFF
--- a/src/main/java/com/ssomar/score/features/custom/particles/particle/ParticleFeature.java
+++ b/src/main/java/com/ssomar/score/features/custom/particles/particle/ParticleFeature.java
@@ -40,7 +40,7 @@ public class ParticleFeature extends FeatureWithHisOwnEditor<ParticleFeature, Pa
     /* specific for the Particle.REDSTONE */
     private BukkitColorFeature redstoneColor;
 
-    /* specific for the Particle.BLOCK_CRACK, BLOCK_DUST, BLOCK_MARKER*/
+    /* specific for the Particle.BLOCK_CRACK, BLOCK_DUST, BLOCK_MARKER, FALLING_DUST*/
     private MaterialFeature blockType;
 
     public ParticleFeature(FeatureParentInterface parent, String id) {
@@ -211,6 +211,7 @@ public class ParticleFeature extends FeatureWithHisOwnEditor<ParticleFeature, Pa
         if (SCore.is1v18Plus()) {
             particles.add(Particle.BLOCK_MARKER);
         }
+        particles.add(Particle.FALLING_DUST);
         return particles;
     }
 

--- a/src/main/java/com/ssomar/score/sparticles/SParticle.java
+++ b/src/main/java/com/ssomar/score/sparticles/SParticle.java
@@ -28,7 +28,7 @@ public class SParticle {
     /* specific for the Particle.REDSTONE */
     private Color redstoneColor;
 
-    /* specific for the Particle.BLOCK_CRACK, BLOCK_DUST, BLOCK_MARKER*/
+    /* specific for the Particle.BLOCK_CRACK, BLOCK_DUST, BLOCK_MARKER, FALLING_DUST*/
     private Material blockType;
 
     public SParticle(String id) {
@@ -127,6 +127,7 @@ public class SParticle {
         if (SCore.is1v18Plus()) {
             particles.add(Particle.BLOCK_MARKER);
         }
+        particles.add(Particle.FALLING_DUST);
         return particles;
     }
 


### PR DESCRIPTION
FALLING_DUST requires BlockData like BLOCK_CRACK/BLOCK_DUST/BLOCK_MARKER, but was missing from getHaveBlocktypeParticles() in both ParticleFeature and SParticle. Without it, no blockType was loaded or passed to spawnParticle(), causing the particle to render incorrectly.

Particle.FALLING_DUST exists in all supported MC versions (pre and post 1.20.5) so no version gating is needed.

Fixes: projectile FALLING_DUST particle not displaying correctly