### PR TITLE
Feat/nbt plch

### DIFF
--- a/src/main/java/com/ssomar/score/features/custom/nbttags/CompoundNBTTag.java
+++ b/src/main/java/com/ssomar/score/features/custom/nbttags/CompoundNBTTag.java
@@ -1,6 +1,5 @@
 package com.ssomar.score.features.custom.nbttags;
 
-import com.ssomar.score.utils.logging.Utils;
 import de.tr7zw.nbtapi.NBTCompound;
 import de.tr7zw.nbtapi.NBTType;
 import de.tr7zw.nbtapi.iface.ReadWriteNBT;

--- a/src/main/java/com/ssomar/score/features/custom/nbttags/CompoundNBTTag.java
+++ b/src/main/java/com/ssomar/score/features/custom/nbttags/CompoundNBTTag.java
@@ -35,7 +35,7 @@ public class CompoundNBTTag extends NBTTag {
 
             switch (type) {
                 case NBTTagInt:
-                    this.nbtTags.add(new IntNBTTag(s, nbtCompound.getInteger(s)));
+                    this.nbtTags.add(new IntNBTTag(s, Integer.toString(nbtCompound.getInteger(s))));
                     break;
                 case NBTTagByte:
                     this.nbtTags.add(new ByteNBTTag(s, nbtCompound.getByte(s)));

--- a/src/main/java/com/ssomar/score/features/custom/nbttags/CompoundNBTTag.java
+++ b/src/main/java/com/ssomar/score/features/custom/nbttags/CompoundNBTTag.java
@@ -35,22 +35,18 @@ public class CompoundNBTTag extends NBTTag {
 
             switch (type) {
                 case NBTTagInt:
-                    Utils.sendConsoleMsg("FLAG 1 TRIGGERED");
                     this.nbtTags.add(new IntNBTTag(s, nbtCompound.getInteger(s)));
                     break;
                 case NBTTagByte:
-                    Utils.sendConsoleMsg("FLAG 2 TRIGGERED");
                     this.nbtTags.add(new ByteNBTTag(s, nbtCompound.getByte(s)));
                     break;
                 case NBTTagByteArray:
                     break;
                 case NBTTagCompound:
-                    Utils.sendConsoleMsg("FLAG 3 TRIGGERED");
                     this.nbtTags.add(new CompoundNBTTag(s, nbtCompound.getCompound(s)));
                     break;
                 case NBTTagDouble:
-                    Utils.sendConsoleMsg("FLAG 4 TRIGGERED");
-                    this.nbtTags.add(new DoubleNBTTag(s, nbtCompound.getDouble(s)));
+                    this.nbtTags.add(new DoubleNBTTag(s, Double.toString(nbtCompound.getDouble(s))));
                     break;
                 case NBTTagEnd:
                     break;
@@ -59,13 +55,13 @@ public class CompoundNBTTag extends NBTTag {
                 case NBTTagIntArray:
                     break;
                 case NBTTagList:
+                    this.nbtTags.add(new ListCompoundNBTTag(s, nbtCompound.getCompoundList(s)));
                     break;
                 case NBTTagLong:
                     break;
                 case NBTTagShort:
                     break;
                 case NBTTagString:
-                    Utils.sendConsoleMsg("FLAG 5 TRIGGERED");
                     this.nbtTags.add(new StringNBTTag(s, nbtCompound.getString(s)));
                     break;
                 default:
@@ -89,7 +85,6 @@ public class CompoundNBTTag extends NBTTag {
     public boolean applyTo(NBTCompound nbtCompound, boolean onlyIfDifferent) {
         //SsomarDev.testMsg(">>> BULD CompoundNBTTag: " + getKey(), true);
         NBTCompound compound = nbtCompound.addCompound(getKey());
-        Utils.sendConsoleMsg("&cCompoundNBTTag FLAG 1");
         boolean different = false;
         for (NBTTag nbtTag : nbtTags) {
             //SsomarDev.testMsg(">>> chldren CompoundNBTTag: " + nbtTag.getKey(), true);
@@ -134,7 +129,6 @@ public class CompoundNBTTag extends NBTTag {
                         break;
                     case "STRING":
                     case "STR":
-                        Utils.sendConsoleMsg("&cCommence Reading : "+tagSection.getKeys(true));
                         tag = new StringNBTTag(tagSection);
                         break;
                     case "DOUBLE":
@@ -149,6 +143,11 @@ public class CompoundNBTTag extends NBTTag {
                         break;
                     case "COMPOUND":
                         tag = new CompoundNBTTag(tagSection);
+                        break;
+                    case "COMPOUND_LIST":
+                        tag = new ListCompoundNBTTag(tagSection);
+                        break;
+                    default:
                         break;
                 }
                 if (tag != null) this.nbtTags.add(tag);

--- a/src/main/java/com/ssomar/score/features/custom/nbttags/CompoundNBTTag.java
+++ b/src/main/java/com/ssomar/score/features/custom/nbttags/CompoundNBTTag.java
@@ -1,5 +1,6 @@
 package com.ssomar.score.features.custom.nbttags;
 
+import com.ssomar.score.utils.logging.Utils;
 import de.tr7zw.nbtapi.NBTCompound;
 import de.tr7zw.nbtapi.NBTType;
 import de.tr7zw.nbtapi.iface.ReadWriteNBT;
@@ -34,17 +35,21 @@ public class CompoundNBTTag extends NBTTag {
 
             switch (type) {
                 case NBTTagInt:
+                    Utils.sendConsoleMsg("FLAG 1 TRIGGERED");
                     this.nbtTags.add(new IntNBTTag(s, nbtCompound.getInteger(s)));
                     break;
                 case NBTTagByte:
+                    Utils.sendConsoleMsg("FLAG 2 TRIGGERED");
                     this.nbtTags.add(new ByteNBTTag(s, nbtCompound.getByte(s)));
                     break;
                 case NBTTagByteArray:
                     break;
                 case NBTTagCompound:
+                    Utils.sendConsoleMsg("FLAG 3 TRIGGERED");
                     this.nbtTags.add(new CompoundNBTTag(s, nbtCompound.getCompound(s)));
                     break;
                 case NBTTagDouble:
+                    Utils.sendConsoleMsg("FLAG 4 TRIGGERED");
                     this.nbtTags.add(new DoubleNBTTag(s, nbtCompound.getDouble(s)));
                     break;
                 case NBTTagEnd:
@@ -60,6 +65,7 @@ public class CompoundNBTTag extends NBTTag {
                 case NBTTagShort:
                     break;
                 case NBTTagString:
+                    Utils.sendConsoleMsg("FLAG 5 TRIGGERED");
                     this.nbtTags.add(new StringNBTTag(s, nbtCompound.getString(s)));
                     break;
                 default:
@@ -83,7 +89,7 @@ public class CompoundNBTTag extends NBTTag {
     public boolean applyTo(NBTCompound nbtCompound, boolean onlyIfDifferent) {
         //SsomarDev.testMsg(">>> BULD CompoundNBTTag: " + getKey(), true);
         NBTCompound compound = nbtCompound.addCompound(getKey());
-
+        Utils.sendConsoleMsg("&cCompoundNBTTag FLAG 1");
         boolean different = false;
         for (NBTTag nbtTag : nbtTags) {
             //SsomarDev.testMsg(">>> chldren CompoundNBTTag: " + nbtTag.getKey(), true);
@@ -128,6 +134,7 @@ public class CompoundNBTTag extends NBTTag {
                         break;
                     case "STRING":
                     case "STR":
+                        Utils.sendConsoleMsg("&cCommence Reading : "+tagSection.getKeys(true));
                         tag = new StringNBTTag(tagSection);
                         break;
                     case "DOUBLE":

--- a/src/main/java/com/ssomar/score/features/custom/nbttags/DoubleNBTTag.java
+++ b/src/main/java/com/ssomar/score/features/custom/nbttags/DoubleNBTTag.java
@@ -9,14 +9,17 @@ import org.bukkit.configuration.ConfigurationSection;
 @Getter
 public class DoubleNBTTag extends NBTTag {
 
-    private double valueDouble;
+    /**
+     * Has to be saved as {@code String} first to support rand placeholder
+     */
+    private String valueDouble;
     private boolean isValueDouble;
 
     public DoubleNBTTag(ConfigurationSection configurationSection) {
         super(configurationSection);
     }
 
-    public DoubleNBTTag(String key, double valueDouble) {
+    public DoubleNBTTag(String key, String valueDouble) {
         super(key);
         this.valueDouble = valueDouble;
         this.isValueDouble = true;
@@ -24,8 +27,9 @@ public class DoubleNBTTag extends NBTTag {
 
     @Override
     public boolean applyTo(ReadWriteNBT nbtItem, boolean onlyIfDifferent) {
-        if (!onlyIfDifferent || nbtItem.getDouble(getKey()) != getValueDouble()) {
-            nbtItem.setString(getKey(), StringPlaceholder.replaceRandomPlaceholders(String.valueOf(getValueDouble())));
+        double doubleValue = Double.parseDouble(StringPlaceholder.replaceRandomPlaceholders(String.valueOf(getValueDouble())));
+        if (!onlyIfDifferent || nbtItem.getDouble(getKey()) != doubleValue) {
+            nbtItem.setDouble(getKey(), doubleValue);
             return true;
         }
         return false;
@@ -33,8 +37,9 @@ public class DoubleNBTTag extends NBTTag {
 
     @Override
     public boolean applyTo(NBTCompound nbtCompound, boolean onlyIfDifferent) {
-        if (!onlyIfDifferent || nbtCompound.getDouble(getKey()) != getValueDouble()) {
-            nbtCompound.setDouble(getKey(), getValueDouble());
+        double doubleValue = Double.parseDouble(StringPlaceholder.replaceRandomPlaceholders(String.valueOf(getValueDouble())));
+        if (!onlyIfDifferent || nbtCompound.getDouble(getKey()) != doubleValue) {
+            nbtCompound.setDouble(getKey(), doubleValue);
             return true;
         }
         return false;
@@ -48,7 +53,7 @@ public class DoubleNBTTag extends NBTTag {
 
     @Override
     public void loadValueFromConfig(ConfigurationSection configurationSection) {
-        this.valueDouble = configurationSection.getDouble("value", 0);
+        this.valueDouble = configurationSection.getString("value", "-1");
     }
 
     @Override

--- a/src/main/java/com/ssomar/score/features/custom/nbttags/DoubleNBTTag.java
+++ b/src/main/java/com/ssomar/score/features/custom/nbttags/DoubleNBTTag.java
@@ -1,5 +1,6 @@
 package com.ssomar.score.features.custom.nbttags;
 
+import com.ssomar.score.utils.placeholders.StringPlaceholder;
 import de.tr7zw.nbtapi.NBTCompound;
 import de.tr7zw.nbtapi.iface.ReadWriteNBT;
 import lombok.Getter;
@@ -24,7 +25,7 @@ public class DoubleNBTTag extends NBTTag {
     @Override
     public boolean applyTo(ReadWriteNBT nbtItem, boolean onlyIfDifferent) {
         if (!onlyIfDifferent || nbtItem.getDouble(getKey()) != getValueDouble()) {
-            nbtItem.setDouble(getKey(), getValueDouble());
+            nbtItem.setString(getKey(), StringPlaceholder.replaceRandomPlaceholders(String.valueOf(getValueDouble())));
             return true;
         }
         return false;

--- a/src/main/java/com/ssomar/score/features/custom/nbttags/DoubleNBTTag.java
+++ b/src/main/java/com/ssomar/score/features/custom/nbttags/DoubleNBTTag.java
@@ -45,10 +45,22 @@ public class DoubleNBTTag extends NBTTag {
         return false;
     }
 
+    /**
+     * Extra work is required for int and double to support random placeholders
+     * @param configurationSection the config pointer in the yml file. May get longer if the plugin is trying to save a really long NBT Compound
+     * @param index usually starts at 0. Goes up if there are sibling NBTs in the nest level of a primary NBT's children
+     */
     @Override
     public void saveValueInConfig(ConfigurationSection configurationSection, Integer index) {
-        configurationSection.set("nbt." + index + ".type", "DOUBLE");
-        configurationSection.set("nbt." + index + ".value", Double.valueOf(getValueDouble()));
+        try {
+            configurationSection.set("nbt." + index + ".type", "DOUBLE");
+            configurationSection.set("nbt." + index + ".value", Double.valueOf(getValueDouble()));
+        } catch (NumberFormatException e) {
+            configurationSection.set("nbt." + index + ".type", "DOUBLE");
+            configurationSection.set("nbt." + index + ".value", getValueDouble());
+        }
+
+
     }
 
     @Override

--- a/src/main/java/com/ssomar/score/features/custom/nbttags/DoubleNBTTag.java
+++ b/src/main/java/com/ssomar/score/features/custom/nbttags/DoubleNBTTag.java
@@ -48,7 +48,7 @@ public class DoubleNBTTag extends NBTTag {
     @Override
     public void saveValueInConfig(ConfigurationSection configurationSection, Integer index) {
         configurationSection.set("nbt." + index + ".type", "DOUBLE");
-        configurationSection.set("nbt." + index + ".value", getValueDouble());
+        configurationSection.set("nbt." + index + ".value", Double.valueOf(getValueDouble()));
     }
 
     @Override

--- a/src/main/java/com/ssomar/score/features/custom/nbttags/IntNBTTag.java
+++ b/src/main/java/com/ssomar/score/features/custom/nbttags/IntNBTTag.java
@@ -9,6 +9,9 @@ import org.bukkit.configuration.ConfigurationSection;
 @Getter
 public class IntNBTTag extends NBTTag {
 
+    /**
+     * Has to be saved as {@code String} first to support rand placeholder
+     */
     private String valueInt;
 
     public IntNBTTag(ConfigurationSection configurationSection) {

--- a/src/main/java/com/ssomar/score/features/custom/nbttags/IntNBTTag.java
+++ b/src/main/java/com/ssomar/score/features/custom/nbttags/IntNBTTag.java
@@ -1,5 +1,6 @@
 package com.ssomar.score.features.custom.nbttags;
 
+import com.ssomar.score.utils.placeholders.StringPlaceholder;
 import de.tr7zw.nbtapi.NBTCompound;
 import de.tr7zw.nbtapi.iface.ReadWriteNBT;
 import lombok.Getter;
@@ -22,7 +23,7 @@ public class IntNBTTag extends NBTTag {
     @Override
     public boolean applyTo(ReadWriteNBT nbtItem, boolean onlyIfDifferent) {
         if (!onlyIfDifferent || nbtItem.getInteger(getKey()) != getValueInt()) {
-            nbtItem.setInteger(getKey(), getValueInt());
+            nbtItem.setInteger(getKey(), Integer.valueOf(StringPlaceholder.replaceRandomPlaceholders(String.valueOf(getValueInt()))));
             return true;
         }
         return false;
@@ -45,7 +46,7 @@ public class IntNBTTag extends NBTTag {
 
     @Override
     public void loadValueFromConfig(ConfigurationSection configurationSection) {
-        this.valueInt = configurationSection.getInt("value", 0);
+        this.valueInt = Integer.parseInt(configurationSection.getString("value", "-1"));
     }
 
     @Override

--- a/src/main/java/com/ssomar/score/features/custom/nbttags/IntNBTTag.java
+++ b/src/main/java/com/ssomar/score/features/custom/nbttags/IntNBTTag.java
@@ -43,10 +43,20 @@ public class IntNBTTag extends NBTTag {
         return false;
     }
 
+    /**
+     * Extra work is required for int and double to support random placeholders
+     * @param configurationSection the config pointer in the yml file. May get longer if the plugin is trying to save a really long NBT Compound
+     * @param index usually starts at 0. Goes up if there are sibling NBTs in the nest level of a primary NBT's children
+     */
     @Override
     public void saveValueInConfig(ConfigurationSection configurationSection, Integer index) {
-        configurationSection.set("nbt." + index + ".type", "INT");
-        configurationSection.set("nbt." + index + ".value", Integer.parseInt(getValueInt()));
+        try {
+            configurationSection.set("nbt." + index + ".type", "INT");
+            configurationSection.set("nbt." + index + ".value", Integer.parseInt(getValueInt()));
+        } catch (NumberFormatException e) {
+            configurationSection.set("nbt." + index + ".type", "INT");
+            configurationSection.set("nbt." + index + ".value", getValueInt());
+        }
     }
 
     @Override

--- a/src/main/java/com/ssomar/score/features/custom/nbttags/IntNBTTag.java
+++ b/src/main/java/com/ssomar/score/features/custom/nbttags/IntNBTTag.java
@@ -9,21 +9,22 @@ import org.bukkit.configuration.ConfigurationSection;
 @Getter
 public class IntNBTTag extends NBTTag {
 
-    private int valueInt;
+    private String valueInt;
 
     public IntNBTTag(ConfigurationSection configurationSection) {
         super(configurationSection);
     }
 
-    public IntNBTTag(String key, int valueInt) {
+    public IntNBTTag(String key, String valueInt) {
         super(key);
         this.valueInt = valueInt;
     }
 
     @Override
     public boolean applyTo(ReadWriteNBT nbtItem, boolean onlyIfDifferent) {
-        if (!onlyIfDifferent || nbtItem.getInteger(getKey()) != getValueInt()) {
-            nbtItem.setInteger(getKey(), Integer.valueOf(StringPlaceholder.replaceRandomPlaceholders(String.valueOf(getValueInt()))));
+        int integerValue = Integer.parseInt(StringPlaceholder.replaceRandomPlaceholders(String.valueOf(getValueInt())));
+        if (!onlyIfDifferent || nbtItem.getInteger(getKey()) != integerValue) {
+            nbtItem.setInteger(getKey(), integerValue);
             return true;
         }
         return false;
@@ -31,8 +32,9 @@ public class IntNBTTag extends NBTTag {
 
     @Override
     public boolean applyTo(NBTCompound nbtCompound, boolean onlyIfDifferent) {
-        if (!onlyIfDifferent || nbtCompound.getInteger(getKey()) != getValueInt()) {
-            nbtCompound.setInteger(getKey(), getValueInt());
+        int integerValue = Integer.parseInt(StringPlaceholder.replaceRandomPlaceholders(String.valueOf(getValueInt())));
+        if (!onlyIfDifferent || nbtCompound.getInteger(getKey()) != integerValue) {
+            nbtCompound.setInteger(getKey(), integerValue);
             return true;
         }
         return false;
@@ -41,12 +43,12 @@ public class IntNBTTag extends NBTTag {
     @Override
     public void saveValueInConfig(ConfigurationSection configurationSection, Integer index) {
         configurationSection.set("nbt." + index + ".type", "INT");
-        configurationSection.set("nbt." + index + ".value", getValueInt());
+        configurationSection.set("nbt." + index + ".value", Integer.parseInt(getValueInt()));
     }
 
     @Override
     public void loadValueFromConfig(ConfigurationSection configurationSection) {
-        this.valueInt = Integer.parseInt(configurationSection.getString("value", "-1"));
+        this.valueInt = configurationSection.getString("value", "-1");
     }
 
     @Override

--- a/src/main/java/com/ssomar/score/features/custom/nbttags/ListCompoundNBTTag.java
+++ b/src/main/java/com/ssomar/score/features/custom/nbttags/ListCompoundNBTTag.java
@@ -44,7 +44,7 @@ ListCompoundNBTTag extends NBTTag {
         for (CompoundNBTTag s : values) {
             ReadWriteNBT nbtListCompound = list.addCompound();
             for (NBTTag t : s.getNbtTags()) {
-                different = t.applyTo(nbtListCompound, onlyIfDifferent);
+                different = t.applyTo(nbtListCompound, onlyIfDifferent) || different;
             }
         }
         return different;
@@ -59,7 +59,7 @@ ListCompoundNBTTag extends NBTTag {
         for (CompoundNBTTag s : values) {
             NBTListCompound nbtListCompound = list.addCompound();
             for (NBTTag t : s.getNbtTags()) {
-                different = t.applyTo(nbtListCompound, onlyIfDifferent);
+                different = t.applyTo(nbtListCompound, onlyIfDifferent) || different;
             }
         }
         return different;

--- a/src/main/java/com/ssomar/score/features/custom/nbttags/ListCompoundNBTTag.java
+++ b/src/main/java/com/ssomar/score/features/custom/nbttags/ListCompoundNBTTag.java
@@ -44,7 +44,7 @@ ListCompoundNBTTag extends NBTTag {
         for (CompoundNBTTag s : values) {
             ReadWriteNBT nbtListCompound = list.addCompound();
             for (NBTTag t : s.getNbtTags()) {
-                different = different || t.applyTo(nbtListCompound, onlyIfDifferent);
+                different = t.applyTo(nbtListCompound, onlyIfDifferent);
             }
         }
         return different;
@@ -59,7 +59,7 @@ ListCompoundNBTTag extends NBTTag {
         for (CompoundNBTTag s : values) {
             NBTListCompound nbtListCompound = list.addCompound();
             for (NBTTag t : s.getNbtTags()) {
-                different = different || t.applyTo(nbtListCompound, onlyIfDifferent);
+                different = t.applyTo(nbtListCompound, onlyIfDifferent);
             }
         }
         return different;

--- a/src/main/java/com/ssomar/score/features/custom/nbttags/NBTTag.java
+++ b/src/main/java/com/ssomar/score/features/custom/nbttags/NBTTag.java
@@ -26,16 +26,38 @@ public abstract class NBTTag {
         this.key = key;
     }
 
+    /**
+     * Saves the values from the source of changes towards the item config. <br/>
+     * @param configurationSection
+     */
     public NBTTag(ConfigurationSection configurationSection) {
         this.key = configurationSection.getString("key");
         this.saveInPDC = configurationSection.getBoolean("saveInPDC", false);
         loadValueFromConfig(configurationSection);
     }
 
+    /**
+     * This method is used to apply nbt details to items. Will be more likely to be executed in cases such as
+     * when you give yourself items via <code>/ei give</code>
+     * @param readWriteNbt
+     * @param onlyIfDifferent currently set to true in the main executor. If set to false, it will ignore conditions in the implementation done by child classes.
+     * @return
+     */
     public abstract boolean applyTo(ReadWriteNBT readWriteNbt, boolean onlyIfDifferent);
 
+    /**
+     * This method is used mainly by ListCompoundNBT to write child nbt tags to items
+     * @param nbtCompound
+     * @param onlyIfDifferent currently set to true in the main executor. If set to false, it will ignore conditions in the implementation done by child classes.
+     * @return
+     */
     public abstract boolean applyTo(NBTCompound nbtCompound, boolean onlyIfDifferent);
 
+    /**
+     * When the user makes changes to the nbt list in the ingame editor or other ways, this method is called to save the changes to the item config.
+     * @param configurationSection
+     * @param index
+     */
     public void saveInConfig(ConfigurationSection configurationSection, Integer index) {
         configurationSection.set("nbt." + index + ".key", getKey());
         if (saveInPDC) configurationSection.set("nbt." + index + ".saveInPDC", true);
@@ -44,5 +66,11 @@ public abstract class NBTTag {
 
     public abstract void saveValueInConfig(ConfigurationSection configurationSection, Integer index);
 
+    /**
+     * Gets executed during plugin load/reload. This is used when class inheritors try to read the nbt field of an item config
+     * and save it in their instance variable: {@code List<NBTTag> nbtTags} for later utilization in {@link NBTTag#applyTo(ReadWriteNBT, boolean)}
+     * and
+     * @param configurationSection
+     */
     public abstract void loadValueFromConfig(ConfigurationSection configurationSection);
 }

--- a/src/main/java/com/ssomar/score/features/custom/nbttags/NBTTag.java
+++ b/src/main/java/com/ssomar/score/features/custom/nbttags/NBTTag.java
@@ -40,7 +40,7 @@ public abstract class NBTTag {
      * This method is used to apply nbt details to items. Will be more likely to be executed in cases such as
      * when you give yourself items via <code>/ei give</code>
      * @param readWriteNbt
-     * @param onlyIfDifferent currently set to true in the main executor. If set to false, it will ignore conditions in the implementation done by child classes.
+     * @param onlyIfDifferent main executor's default value is {@code true}. It's to prevent accidental rewrite of nbt because previous reports complained about nbt getting shuffled around and having the wrong order
      * @return
      */
     public abstract boolean applyTo(ReadWriteNBT readWriteNbt, boolean onlyIfDifferent);
@@ -48,7 +48,7 @@ public abstract class NBTTag {
     /**
      * This method is used mainly by ListCompoundNBT to write child nbt tags to items
      * @param nbtCompound
-     * @param onlyIfDifferent currently set to true in the main executor. If set to false, it will ignore conditions in the implementation done by child classes.
+     * @param onlyIfDifferent main executor's default value is {@code true}. It's to prevent accidental rewrite of nbt because previous reports complained about nbt getting shuffled around and having the wrong order
      * @return
      */
     public abstract boolean applyTo(NBTCompound nbtCompound, boolean onlyIfDifferent);
@@ -64,6 +64,11 @@ public abstract class NBTTag {
         saveValueInConfig(configurationSection, index);
     }
 
+    /**
+     * This method is used to save custom nbt details to an ExecutableItem's yml config.
+     * @param configurationSection the config pointer in the yml file. May get longer if the plugin is trying to save a really long NBT Compound
+     * @param index usually starts at 0. Goes up if there are sibling NBTs in the nest level of a primary NBT's children
+     */
     public abstract void saveValueInConfig(ConfigurationSection configurationSection, Integer index);
 
     /**

--- a/src/main/java/com/ssomar/score/features/custom/nbttags/NBTTagNBTAPIApplier.java
+++ b/src/main/java/com/ssomar/score/features/custom/nbttags/NBTTagNBTAPIApplier.java
@@ -14,6 +14,11 @@ import java.util.List;
  */
 public class NBTTagNBTAPIApplier {
 
+    /**
+     * Applys NBTs to items using NBT API plugin
+     * @param item the item that will receive the custom nbts
+     * @param tags the tags
+     */
     public static void applyTags(ItemStack item, List<NBTTag> tags) {
         NBT.modify(item, nbtItem -> {
             for (NBTTag nbtTag : tags) {

--- a/src/main/java/com/ssomar/score/features/custom/nbttags/NBTTags.java
+++ b/src/main/java/com/ssomar/score/features/custom/nbttags/NBTTags.java
@@ -64,6 +64,10 @@ public class NBTTags extends FeatureAbstract<Optional<List<String>>, NBTTags> im
         return blackListedTags;
     }
 
+    /**
+     * This method is used for importing custom nbt values from the held reference ItemStack when running <code>/ei create</code>
+     * @param item
+     */
     public void load(ItemStack item) {
         if (SCore.hasNBTAPI) {
             NBTItem nbti = new NBTItem(item);
@@ -86,7 +90,7 @@ public class NBTTags extends FeatureAbstract<Optional<List<String>>, NBTTags> im
                         tags.add(new CompoundNBTTag(s, nbti.getCompound(s)));
                         break;
                     case NBTTagDouble:
-                        tags.add(new DoubleNBTTag(s, nbti.getDouble(s).doubleValue()));
+                        tags.add(new DoubleNBTTag(s, Double.toString(nbti.getDouble(s).doubleValue())));
                         break;
                     case NBTTagList:
                         /* Important for attributes in 1.12 */
@@ -108,6 +112,13 @@ public class NBTTags extends FeatureAbstract<Optional<List<String>>, NBTTags> im
         }
     }
 
+    /**
+     * This method is typically executed during plugin load and reloads
+     * @param sPlugin
+     * @param configurationSection
+     * @param isPremiumLoading
+     * @return
+     */
     @Override
     public List<String> load(SPlugin sPlugin, ConfigurationSection configurationSection, boolean isPremiumLoading) {
         tags.clear();
@@ -279,7 +290,7 @@ public class NBTTags extends FeatureAbstract<Optional<List<String>>, NBTTags> im
                     } else if (tag instanceof IntNBTTag) {
                         pdc.set(nsKey, PersistentDataType.INTEGER, ((IntNBTTag) tag).getValueInt());
                     } else if (tag instanceof DoubleNBTTag) {
-                        pdc.set(nsKey, PersistentDataType.DOUBLE, ((DoubleNBTTag) tag).getValueDouble());
+                        pdc.set(nsKey, PersistentDataType.DOUBLE, Double.valueOf(((DoubleNBTTag) tag).getValueDouble()));
                     } else if (tag instanceof BooleanNBTTag) {
                         // PDC has no dedicated boolean type; store as BYTE (0/1)
                         pdc.set(nsKey, PersistentDataType.BYTE,

--- a/src/main/java/com/ssomar/score/features/custom/nbttags/NBTTags.java
+++ b/src/main/java/com/ssomar/score/features/custom/nbttags/NBTTags.java
@@ -15,6 +15,7 @@ import com.ssomar.score.menu.EditorCreator;
 import com.ssomar.score.menu.GUI;
 import com.ssomar.score.splugin.SPlugin;
 import com.ssomar.score.utils.logging.Utils;
+import com.ssomar.score.utils.placeholders.StringPlaceholder;
 import com.ssomar.score.utils.strings.StringConverter;
 import de.tr7zw.nbtapi.NBTItem;
 import de.tr7zw.nbtapi.NBTType;
@@ -288,9 +289,9 @@ public class NBTTags extends FeatureAbstract<Optional<List<String>>, NBTTags> im
                     if (tag instanceof StringNBTTag) {
                         pdc.set(nsKey, PersistentDataType.STRING, ((StringNBTTag) tag).getValueString());
                     } else if (tag instanceof IntNBTTag) {
-                        pdc.set(nsKey, PersistentDataType.INTEGER, Integer.parseInt(((IntNBTTag) tag).getValueInt()));
+                        pdc.set(nsKey, PersistentDataType.INTEGER, Integer.parseInt(StringPlaceholder.replaceRandomPlaceholders(((IntNBTTag) tag).getValueInt())));
                     } else if (tag instanceof DoubleNBTTag) {
-                        pdc.set(nsKey, PersistentDataType.DOUBLE, Double.parseDouble(((DoubleNBTTag) tag).getValueDouble()));
+                        pdc.set(nsKey, PersistentDataType.DOUBLE, Double.parseDouble(StringPlaceholder.replaceRandomPlaceholders(((DoubleNBTTag) tag).getValueDouble())));
                     } else if (tag instanceof BooleanNBTTag) {
                         // PDC has no dedicated boolean type; store as BYTE (0/1)
                         pdc.set(nsKey, PersistentDataType.BYTE,

--- a/src/main/java/com/ssomar/score/features/custom/nbttags/NBTTags.java
+++ b/src/main/java/com/ssomar/score/features/custom/nbttags/NBTTags.java
@@ -14,6 +14,7 @@ import com.ssomar.score.languages.messages.Text;
 import com.ssomar.score.menu.EditorCreator;
 import com.ssomar.score.menu.GUI;
 import com.ssomar.score.splugin.SPlugin;
+import com.ssomar.score.utils.logging.Utils;
 import com.ssomar.score.utils.strings.StringConverter;
 import de.tr7zw.nbtapi.NBTItem;
 import de.tr7zw.nbtapi.NBTType;

--- a/src/main/java/com/ssomar/score/features/custom/nbttags/NBTTags.java
+++ b/src/main/java/com/ssomar/score/features/custom/nbttags/NBTTags.java
@@ -81,7 +81,7 @@ public class NBTTags extends FeatureAbstract<Optional<List<String>>, NBTTags> im
                 SsomarDev.testMsg(" >>>>>>> load tag: " + s+" type: "+type, true);
                 switch (type) {
                     case NBTTagInt:
-                        tags.add(new IntNBTTag(s, nbti.getInteger(s).intValue()));
+                        tags.add(new IntNBTTag(s, Integer.toString(nbti.getInteger(s).intValue())));
                         break;
                     case NBTTagByte:
                         tags.add(new ByteNBTTag(s, nbti.getByte(s).byteValue()));
@@ -288,9 +288,9 @@ public class NBTTags extends FeatureAbstract<Optional<List<String>>, NBTTags> im
                     if (tag instanceof StringNBTTag) {
                         pdc.set(nsKey, PersistentDataType.STRING, ((StringNBTTag) tag).getValueString());
                     } else if (tag instanceof IntNBTTag) {
-                        pdc.set(nsKey, PersistentDataType.INTEGER, ((IntNBTTag) tag).getValueInt());
+                        pdc.set(nsKey, PersistentDataType.INTEGER, Integer.parseInt(((IntNBTTag) tag).getValueInt()));
                     } else if (tag instanceof DoubleNBTTag) {
-                        pdc.set(nsKey, PersistentDataType.DOUBLE, Double.valueOf(((DoubleNBTTag) tag).getValueDouble()));
+                        pdc.set(nsKey, PersistentDataType.DOUBLE, Double.parseDouble(((DoubleNBTTag) tag).getValueDouble()));
                     } else if (tag instanceof BooleanNBTTag) {
                         // PDC has no dedicated boolean type; store as BYTE (0/1)
                         pdc.set(nsKey, PersistentDataType.BYTE,

--- a/src/main/java/com/ssomar/score/features/custom/nbttags/StringNBTTag.java
+++ b/src/main/java/com/ssomar/score/features/custom/nbttags/StringNBTTag.java
@@ -23,12 +23,6 @@ public class StringNBTTag extends NBTTag {
         this.isValueString = true;
     }
 
-    /**
-     * This method is used to get the nbt key values from the EI config.
-     * @param nbtItem
-     * @param onlyIfDifferent
-     * @return
-     */
     @Override
     public boolean applyTo(ReadWriteNBT nbtItem, boolean onlyIfDifferent) {
         if (!onlyIfDifferent || !nbtItem.getString(getKey()).equals(getValueString())) {

--- a/src/main/java/com/ssomar/score/features/custom/nbttags/StringNBTTag.java
+++ b/src/main/java/com/ssomar/score/features/custom/nbttags/StringNBTTag.java
@@ -4,7 +4,6 @@ import com.ssomar.score.utils.placeholders.StringPlaceholder;
 import de.tr7zw.nbtapi.NBTCompound;
 import de.tr7zw.nbtapi.iface.ReadWriteNBT;
 import lombok.Getter;
-import me.clip.placeholderapi.PlaceholderAPI;
 import org.bukkit.configuration.ConfigurationSection;
 
 @Getter

--- a/src/main/java/com/ssomar/score/features/custom/nbttags/StringNBTTag.java
+++ b/src/main/java/com/ssomar/score/features/custom/nbttags/StringNBTTag.java
@@ -1,8 +1,10 @@
 package com.ssomar.score.features.custom.nbttags;
 
+import com.ssomar.score.utils.placeholders.StringPlaceholder;
 import de.tr7zw.nbtapi.NBTCompound;
 import de.tr7zw.nbtapi.iface.ReadWriteNBT;
 import lombok.Getter;
+import me.clip.placeholderapi.PlaceholderAPI;
 import org.bukkit.configuration.ConfigurationSection;
 
 @Getter
@@ -21,10 +23,16 @@ public class StringNBTTag extends NBTTag {
         this.isValueString = true;
     }
 
+    /**
+     * This method is used to get the nbt key values from the EI config.
+     * @param nbtItem
+     * @param onlyIfDifferent
+     * @return
+     */
     @Override
     public boolean applyTo(ReadWriteNBT nbtItem, boolean onlyIfDifferent) {
         if (!onlyIfDifferent || !nbtItem.getString(getKey()).equals(getValueString())) {
-            nbtItem.setString(getKey(), getValueString());
+            nbtItem.setString(getKey(), StringPlaceholder.replaceRandomPlaceholders(getValueString()));
             return true;
         }
         return false;


### PR DESCRIPTION
For Ssomar to copypaste to changelog
- Fixed issues when adding custom int and double values to the nbt editor
- String, Integer and Double values can now use the rand placeholder (Ex: %rand:-10|10%)
- Fixed issues of ExecutableItems not being able to import ListCompoundNBTs

For Ssomar to read:
- Integer and Double nbts are still saved as proper int and double values but can now utilize the rand placeholder from StringPlaceholders. However,
if the user attempts to view it in the ingame editor, issues will occur. If ever this PR is approved, an issue post must be made in SCore's repo because it's
hard to look for it in Discord if I need to revisit this issue.
- Added Javadoc comments to all of the methods in NBTTags 
- Rearranged the position of the different variable in ListCompoundNBTTag because during testing, the logic prevented of the writing of other
elements of the list, causing issues in writing the necessary nbt to write valid AuraSkills item modifier nbt.
- Test Cases:
	- No issues importing nbt data from an ItemStack with AuraSkills modifier nbt
	- No issues adding and saving integer and double nbts whether it's a raw or pdc variable
	- No issues with the parsing of rand plch on Integer and Double nbt in the item config

I'm really burnt out because I failed to manage my work-life balance and my obsession in making this PR done because I've been slacking and regaining my discipline ever since the school year ended. 
The current state of this PR is good for merge as it's not showing any odd issues when executing modified code but second opinions would be appreciated.