### PR TITLE
Added folia checks to teleport method calls

### DIFF
--- a/src/main/java/com/ssomar/score/commands/runnable/entity/commands/TeleportEntityToPlayer.java
+++ b/src/main/java/com/ssomar/score/commands/runnable/entity/commands/TeleportEntityToPlayer.java
@@ -1,5 +1,6 @@
 package com.ssomar.score.commands.runnable.entity.commands;
 
+import com.ssomar.score.SCore;
 import com.ssomar.score.commands.runnable.SCommandToExec;
 import com.ssomar.score.commands.runnable.entity.EntityCommand;
 import org.bukkit.ChatColor;
@@ -21,7 +22,10 @@ public class TeleportEntityToPlayer extends EntityCommand {
         Location pLoc = p.getLocation();
 
         if (!entity.isDead() && p.isOnline() && !p.isDead())
-            entity.teleport(new Location(p.getWorld(), pLoc.getX(), pLoc.getY(), pLoc.getZ()));
+            if (SCore.isFolia())
+                entity.teleportAsync(new Location(p.getWorld(), pLoc.getX(), pLoc.getY(), pLoc.getZ()));
+            else
+                entity.teleport(new Location(p.getWorld(), pLoc.getX(), pLoc.getY(), pLoc.getZ()));
     }
 
     @Override

--- a/src/main/java/com/ssomar/score/commands/runnable/entity/commands/TeleportPlayerToEntity.java
+++ b/src/main/java/com/ssomar/score/commands/runnable/entity/commands/TeleportPlayerToEntity.java
@@ -1,5 +1,6 @@
 package com.ssomar.score.commands.runnable.entity.commands;
 
+import com.ssomar.score.SCore;
 import com.ssomar.score.commands.runnable.SCommandToExec;
 import com.ssomar.score.commands.runnable.entity.EntityCommand;
 import org.bukkit.ChatColor;
@@ -21,7 +22,10 @@ public class TeleportPlayerToEntity extends EntityCommand {
         Location eLoc = entity.getLocation();
 
         if (!entity.isDead() && p.isOnline() && !p.isDead())
-            p.teleport(new Location(entity.getWorld(), eLoc.getX(), eLoc.getY(), eLoc.getZ()));
+            if (SCore.isFolia())
+                p.teleportAsync(new Location(entity.getWorld(), eLoc.getX(), eLoc.getY(), eLoc.getZ()));
+            else
+                p.teleport(new Location(entity.getWorld(), eLoc.getX(), eLoc.getY(), eLoc.getZ()));
     }
 
     @Override

--- a/src/main/java/com/ssomar/score/commands/runnable/entity/commands/TeleportPosition.java
+++ b/src/main/java/com/ssomar/score/commands/runnable/entity/commands/TeleportPosition.java
@@ -1,5 +1,6 @@
 package com.ssomar.score.commands.runnable.entity.commands;
 
+import com.ssomar.score.SCore;
 import com.ssomar.score.commands.runnable.CommandSetting;
 import com.ssomar.score.commands.runnable.SCommandToExec;
 import com.ssomar.score.commands.runnable.entity.EntityCommand;
@@ -34,7 +35,10 @@ public class TeleportPosition extends EntityCommand {
         List<String> args = sCommandToExec.getOtherArgs();
         if (args.size() == 3) {
             if (!entity.isDead())
-                entity.teleport(new Location(entity.getWorld(), x, y, z));
+                if (SCore.isFolia())
+                    entity.teleportAsync(new Location(entity.getWorld(), x, y, z));
+                else
+                    entity.teleport(new Location(entity.getWorld(), x, y, z));
         }
     }
 

--- a/src/main/java/com/ssomar/score/commands/runnable/mixed_player_entity/commands/SetPitch.java
+++ b/src/main/java/com/ssomar/score/commands/runnable/mixed_player_entity/commands/SetPitch.java
@@ -1,5 +1,6 @@
 package com.ssomar.score.commands.runnable.mixed_player_entity.commands;
 
+import com.ssomar.score.SCore;
 import com.ssomar.score.commands.runnable.ArgumentChecker;
 import com.ssomar.score.commands.runnable.SCommandToExec;
 import com.ssomar.score.commands.runnable.mixed_player_entity.MixedCommand;
@@ -26,7 +27,10 @@ public class SetPitch extends MixedCommand {
         Vector velocity = receiver.getVelocity().clone();
         Location location = receiver.getLocation();
         location.setPitch(pitch);
-        receiver.teleport(location);
+        if (SCore.isFolia())
+            receiver.teleportAsync(location);
+        else
+            receiver.teleport(location);
         if(keepVelocity) receiver.setVelocity(velocity);
     }
 

--- a/src/main/java/com/ssomar/score/commands/runnable/mixed_player_entity/commands/SetYaw.java
+++ b/src/main/java/com/ssomar/score/commands/runnable/mixed_player_entity/commands/SetYaw.java
@@ -1,5 +1,6 @@
 package com.ssomar.score.commands.runnable.mixed_player_entity.commands;
 
+import com.ssomar.score.SCore;
 import com.ssomar.score.commands.runnable.ArgumentChecker;
 import com.ssomar.score.commands.runnable.SCommandToExec;
 import com.ssomar.score.commands.runnable.mixed_player_entity.MixedCommand;
@@ -26,7 +27,10 @@ public class SetYaw extends MixedCommand {
         Vector velocity = receiver.getVelocity();
         Location location = receiver.getLocation();
         location.setYaw(yaw);
-        receiver.teleport(location);
+        if (SCore.isFolia())
+            receiver.teleportAsync(location);
+        else
+            receiver.teleport(location);
         if(keepVelocity) receiver.setVelocity(velocity);
     }
 

--- a/src/main/java/com/ssomar/score/commands/runnable/mixed_player_entity/commands/Spin.java
+++ b/src/main/java/com/ssomar/score/commands/runnable/mixed_player_entity/commands/Spin.java
@@ -36,7 +36,11 @@ public class Spin extends MixedCommand {
                     task.get().cancel();
                     return;
                 }
-                receiver.teleport(receiver.getLocation().setDirection(receiver.getLocation().getDirection()
+                if (SCore.isFolia())
+                    receiver.teleportAsync(receiver.getLocation().setDirection(receiver.getLocation().getDirection()
+                            .rotateAroundY(Math.toRadians(velocity))));
+                else
+                    receiver.teleport(receiver.getLocation().setDirection(receiver.getLocation().getDirection()
                         .rotateAroundY(Math.toRadians(velocity))));
                 ticks++;
             }

--- a/src/main/java/com/ssomar/score/commands/runnable/mixed_player_entity/commands/StunEnable.java
+++ b/src/main/java/com/ssomar/score/commands/runnable/mixed_player_entity/commands/StunEnable.java
@@ -30,7 +30,10 @@ public class StunEnable extends MixedCommand {
             correctAnimation.setPitch(45F);
             livingReceiver.setAI(false);
         }
-        receiver.teleport(correctAnimation);
+        if (SCore.isFolia())
+            receiver.teleportAsync(correctAnimation);
+        else
+            receiver.teleport(correctAnimation);
         StunEvent.stunPlayers.put(receiver.getUniqueId(), false);
         Runnable runnable3 = new Runnable() {
             @Override

--- a/src/main/java/com/ssomar/score/commands/runnable/mixed_player_entity/commands/Teleport.java
+++ b/src/main/java/com/ssomar/score/commands/runnable/mixed_player_entity/commands/Teleport.java
@@ -1,5 +1,6 @@
 package com.ssomar.score.commands.runnable.mixed_player_entity.commands;
 
+import com.ssomar.score.SCore;
 import com.ssomar.score.commands.runnable.ArgumentChecker;
 import com.ssomar.score.commands.runnable.SCommandToExec;
 import com.ssomar.score.commands.runnable.mixed_player_entity.MixedCommand;
@@ -40,7 +41,10 @@ public class Teleport extends MixedCommand {
         Location loc = new Location(world, x, y, z);
         loc.setPitch(pitch);
         loc.setYaw(yaw);
-        receiver.teleport(loc);
+        if (SCore.isFolia())
+            receiver.teleportAsync(loc);
+        else
+            receiver.teleport(loc);
         if(keepVelocity) receiver.setVelocity(velocity);
     }
 

--- a/src/main/java/com/ssomar/score/commands/runnable/mixed_player_entity/commands/TeleportOnCursor.java
+++ b/src/main/java/com/ssomar/score/commands/runnable/mixed_player_entity/commands/TeleportOnCursor.java
@@ -64,10 +64,10 @@ public class TeleportOnCursor extends MixedCommand {
 
             if (validTp && isAirBlock(checkLoc.clone().add(0, 1, 0).getBlock()) && isAirBlock(checkLoc.clone().add(0, 2, 0).getBlock())) {
                 if (TeleportOnCursorManager.getInstance().canTp(receiver.getUniqueId())) {
-                    if(SCore.isFolia()){
-                     receiver.teleportAsync(checkLoc.add(0, 1, 0));
-                    }
-                    else receiver.teleport(checkLoc.add(0, 1, 0));
+                    if(SCore.isFolia())
+                        receiver.teleportAsync(checkLoc.add(0, 1, 0));
+                    else
+                        receiver.teleport(checkLoc.add(0, 1, 0));
                     SsomarDev.testMsg("TeleportOnCursor command executed on entity: " + receiver.getType() + " at location: " + checkLoc, true);
                 }
 

--- a/src/main/java/com/ssomar/score/commands/runnable/mixed_player_entity/commands/UnsafeTeleportOnCursor.java
+++ b/src/main/java/com/ssomar/score/commands/runnable/mixed_player_entity/commands/UnsafeTeleportOnCursor.java
@@ -53,7 +53,10 @@ public class UnsafeTeleportOnCursor extends MixedCommand {
                 Location toTeleport = lastAirBlock.getLocation();
                 toTeleport.setPitch(receiver.getLocation().getPitch());
                 toTeleport.setYaw(receiver.getLocation().getYaw());
-                receiver.teleport(toTeleport);
+                if (SCore.isFolia())
+                    receiver.teleportAsync(toTeleport);
+                else
+                    receiver.teleport(toTeleport);
             }
 
         } catch (Exception ignored) {

--- a/src/main/java/com/ssomar/score/commands/runnable/mixed_player_entity/commands/WorldTeleport.java
+++ b/src/main/java/com/ssomar/score/commands/runnable/mixed_player_entity/commands/WorldTeleport.java
@@ -56,7 +56,10 @@ public class WorldTeleport extends MixedCommand {
                                 break;
                             }
                             newLoc.add(0, 1, 0);
-                            receiver.teleport(newLoc);
+                            if (SCore.isFolia())
+                                receiver.teleportAsync(newLoc);
+                            else
+                                receiver.teleport(newLoc);
                             teleport = true;
                             break;
                         } else {
@@ -77,7 +80,10 @@ public class WorldTeleport extends MixedCommand {
                     if (newLoc.getBlock().isEmpty() && newLoc.getY() > 0) continue;
                     else if (!newLoc.getBlock().isEmpty()) {
                         newLoc.add(0, 1, 0);
-                        receiver.teleport(newLoc);
+                        if (SCore.isFolia())
+                            receiver.teleportAsync(newLoc);
+                        else
+                            receiver.teleport(newLoc);
                         teleport = true;
                     }
                 }

--- a/src/main/java/com/ssomar/score/commands/runnable/player/commands/FlyOff.java
+++ b/src/main/java/com/ssomar/score/commands/runnable/player/commands/FlyOff.java
@@ -1,5 +1,6 @@
 package com.ssomar.score.commands.runnable.player.commands;
 
+import com.ssomar.score.SCore;
 import com.ssomar.score.commands.runnable.CommandSetting;
 import com.ssomar.score.commands.runnable.SCommandToExec;
 import com.ssomar.score.commands.runnable.player.PlayerCommand;
@@ -38,7 +39,10 @@ public class FlyOff extends PlayerCommand {
                 }
                 if (!isVoid) {
                     playerLocation.add(0, 1, 0);
-                    receiver.teleport(playerLocation);
+                    if (SCore.isFolia())
+                        receiver.teleportAsync(playerLocation);
+                    else
+                        receiver.teleport(playerLocation);
                 }
             }
         }

--- a/src/main/java/com/ssomar/score/commands/runnable/player/commands/ProjectileCustomDash1.java
+++ b/src/main/java/com/ssomar/score/commands/runnable/player/commands/ProjectileCustomDash1.java
@@ -30,7 +30,10 @@ public class ProjectileCustomDash1 extends PlayerCommand {
     private static void pullEntityToLocation(Entity e, Location loc) {
         Location entityLoc = e.getLocation();
         entityLoc.setY(entityLoc.getY() + 0.5D);
-        e.teleport(entityLoc);
+        if (SCore.isFolia())
+            e.teleportAsync(entityLoc);
+        else
+            e.teleport(entityLoc);
         double g = -0.08D;
         double v_x = (1.0D + 0.07D * loc.distance(entityLoc)) * (loc.getX() - entityLoc.getX()) / loc.distance(entityLoc);
         double v_y = (1.0D + 0.03D * loc.distance(entityLoc)) * (loc.getY() - entityLoc.getY()) / loc.distance(entityLoc) - 0.5D * g * loc.distance(entityLoc);


### PR DESCRIPTION
Although paper doesn't demand it, if we want to support Folia users properly, all teleport calls have to be done asynchronously.

Reference error:
```
Caused by: java.lang.UnsupportedOperationException: Must use teleportAsync while in region threading
        at org.bukkit.craftbukkit.entity.CraftPlayer.teleport0(CraftPlayer.java:1337) ~[folia-1.21.11.jar:1.21.11-14-529aabc]
```