### PR TITLE
Rewritten applyTo() methods to not immediately use NBT API classes

### DIFF
--- a/src/main/java/com/ssomar/score/features/custom/nbttags/BooleanNBTTag.java
+++ b/src/main/java/com/ssomar/score/features/custom/nbttags/BooleanNBTTag.java
@@ -1,5 +1,6 @@
 package com.ssomar.score.features.custom.nbttags;
 
+import com.ssomar.score.SCore;
 import de.tr7zw.nbtapi.NBTCompound;
 import de.tr7zw.nbtapi.iface.ReadWriteNBT;
 import lombok.Getter;
@@ -22,7 +23,12 @@ public class BooleanNBTTag extends NBTTag {
     }
 
     @Override
-    public boolean applyTo(ReadWriteNBT nbtItem, boolean onlyIfDifferent) {
+    public boolean applyTo(Object nbtItemOpt, boolean onlyIfDifferent) {
+        ReadWriteNBT nbtItem = null;
+        if (SCore.hasNBTAPI) {
+            nbtItem = (ReadWriteNBT) nbtItemOpt;
+        } else return false;
+
         if (!onlyIfDifferent || nbtItem.getBoolean(getKey()) != isValueBoolean()) {
             nbtItem.setBoolean(getKey(), isValueBoolean());
             return true;
@@ -31,7 +37,12 @@ public class BooleanNBTTag extends NBTTag {
     }
 
     @Override
-    public boolean applyTo(NBTCompound nbtCompound, boolean onlyIfDifferent) {
+    public boolean applyToComp(Object nbtCompoundOpt, boolean onlyIfDifferent) {
+        NBTCompound nbtCompound = null;
+        if (SCore.hasNBTAPI) {
+            nbtCompound = (NBTCompound) nbtCompoundOpt;
+        } else return false;
+
         if (!onlyIfDifferent || nbtCompound.getBoolean(getKey()) != isValueBoolean()) {
             nbtCompound.setBoolean(getKey(), isValueBoolean);
             return true;

--- a/src/main/java/com/ssomar/score/features/custom/nbttags/ByteNBTTag.java
+++ b/src/main/java/com/ssomar/score/features/custom/nbttags/ByteNBTTag.java
@@ -1,5 +1,6 @@
 package com.ssomar.score.features.custom.nbttags;
 
+import com.ssomar.score.SCore;
 import de.tr7zw.nbtapi.NBTCompound;
 import de.tr7zw.nbtapi.iface.ReadWriteNBT;
 import lombok.Getter;
@@ -22,7 +23,12 @@ public class ByteNBTTag extends NBTTag {
     }
 
     @Override
-    public boolean applyTo(ReadWriteNBT nbtItem, boolean onlyIfDifferent) {
+    public boolean applyTo(Object nbtItemOpt, boolean onlyIfDifferent) {
+        ReadWriteNBT nbtItem = null;
+        if (SCore.hasNBTAPI) {
+            nbtItem = (ReadWriteNBT) nbtItemOpt;
+        } else return false;
+
         if (!onlyIfDifferent || nbtItem.getByte(getKey()) != getValueByte()) {
             nbtItem.setByte(getKey(), getValueByte());
             return true;
@@ -31,7 +37,12 @@ public class ByteNBTTag extends NBTTag {
     }
 
     @Override
-    public boolean applyTo(NBTCompound nbtCompound, boolean onlyIfDifferent) {
+    public boolean applyToComp(Object nbtCompoundOpt, boolean onlyIfDifferent) {
+        NBTCompound nbtCompound = null;
+        if (SCore.hasNBTAPI) {
+            nbtCompound = (NBTCompound) nbtCompoundOpt;
+        } else return false;
+
         if (!onlyIfDifferent || nbtCompound.getByte(getKey()) != getValueByte()) {
             nbtCompound.setByte(getKey(), getValueByte());
             return true;

--- a/src/main/java/com/ssomar/score/features/custom/nbttags/CompoundNBTTag.java
+++ b/src/main/java/com/ssomar/score/features/custom/nbttags/CompoundNBTTag.java
@@ -1,5 +1,6 @@
 package com.ssomar.score.features.custom.nbttags;
 
+import com.ssomar.score.SCore;
 import de.tr7zw.nbtapi.NBTCompound;
 import de.tr7zw.nbtapi.NBTType;
 import de.tr7zw.nbtapi.iface.ReadWriteNBT;
@@ -70,7 +71,11 @@ public class CompoundNBTTag extends NBTTag {
     }
 
     @Override
-    public boolean applyTo(ReadWriteNBT nbtItem, boolean onlyIfDifferent) {
+    public boolean applyTo(Object nbtItemOpt, boolean onlyIfDifferent) {
+        ReadWriteNBT nbtItem = null;
+        if (SCore.hasNBTAPI) {
+            nbtItem = (ReadWriteNBT) nbtItemOpt;
+        } else return false;
         ReadWriteNBT compound = nbtItem.getOrCreateCompound(getKey());
 
         boolean different = false;
@@ -81,7 +86,12 @@ public class CompoundNBTTag extends NBTTag {
     }
 
     @Override
-    public boolean applyTo(NBTCompound nbtCompound, boolean onlyIfDifferent) {
+    public boolean applyToComp(Object nbtCompoundOpt, boolean onlyIfDifferent) {
+        NBTCompound nbtCompound = null;
+        if (SCore.hasNBTAPI) {
+            nbtCompound = (NBTCompound) nbtCompoundOpt;
+        } else return false;
+
         //SsomarDev.testMsg(">>> BULD CompoundNBTTag: " + getKey(), true);
         NBTCompound compound = nbtCompound.addCompound(getKey());
         boolean different = false;

--- a/src/main/java/com/ssomar/score/features/custom/nbttags/DoubleNBTTag.java
+++ b/src/main/java/com/ssomar/score/features/custom/nbttags/DoubleNBTTag.java
@@ -1,5 +1,6 @@
 package com.ssomar.score.features.custom.nbttags;
 
+import com.ssomar.score.SCore;
 import com.ssomar.score.utils.placeholders.StringPlaceholder;
 import de.tr7zw.nbtapi.NBTCompound;
 import de.tr7zw.nbtapi.iface.ReadWriteNBT;
@@ -26,7 +27,12 @@ public class DoubleNBTTag extends NBTTag {
     }
 
     @Override
-    public boolean applyTo(ReadWriteNBT nbtItem, boolean onlyIfDifferent) {
+    public boolean applyTo(Object nbtItemOpt, boolean onlyIfDifferent) {
+        ReadWriteNBT nbtItem = null;
+        if (SCore.hasNBTAPI) {
+            nbtItem = (ReadWriteNBT) nbtItemOpt;
+        } else return false;
+
         double doubleValue = Double.parseDouble(StringPlaceholder.replaceRandomPlaceholders(String.valueOf(getValueDouble())));
         if (!onlyIfDifferent || nbtItem.getDouble(getKey()) != doubleValue) {
             nbtItem.setDouble(getKey(), doubleValue);
@@ -36,7 +42,12 @@ public class DoubleNBTTag extends NBTTag {
     }
 
     @Override
-    public boolean applyTo(NBTCompound nbtCompound, boolean onlyIfDifferent) {
+    public boolean applyToComp(Object nbtCompoundOpt, boolean onlyIfDifferent) {
+        NBTCompound nbtCompound = null;
+        if (SCore.hasNBTAPI) {
+            nbtCompound = (NBTCompound) nbtCompoundOpt;
+        } else return false;
+
         double doubleValue = Double.parseDouble(StringPlaceholder.replaceRandomPlaceholders(String.valueOf(getValueDouble())));
         if (!onlyIfDifferent || nbtCompound.getDouble(getKey()) != doubleValue) {
             nbtCompound.setDouble(getKey(), doubleValue);

--- a/src/main/java/com/ssomar/score/features/custom/nbttags/IntNBTTag.java
+++ b/src/main/java/com/ssomar/score/features/custom/nbttags/IntNBTTag.java
@@ -1,5 +1,6 @@
 package com.ssomar.score.features.custom.nbttags;
 
+import com.ssomar.score.SCore;
 import com.ssomar.score.utils.placeholders.StringPlaceholder;
 import de.tr7zw.nbtapi.NBTCompound;
 import de.tr7zw.nbtapi.iface.ReadWriteNBT;
@@ -24,7 +25,12 @@ public class IntNBTTag extends NBTTag {
     }
 
     @Override
-    public boolean applyTo(ReadWriteNBT nbtItem, boolean onlyIfDifferent) {
+    public boolean applyTo(Object nbtItemOpt, boolean onlyIfDifferent) {
+        ReadWriteNBT nbtItem = null;
+        if (SCore.hasNBTAPI) {
+            nbtItem = (ReadWriteNBT) nbtItemOpt;
+        } else return false;
+
         int integerValue = Integer.parseInt(StringPlaceholder.replaceRandomPlaceholders(String.valueOf(getValueInt())));
         if (!onlyIfDifferent || nbtItem.getInteger(getKey()) != integerValue) {
             nbtItem.setInteger(getKey(), integerValue);
@@ -34,7 +40,12 @@ public class IntNBTTag extends NBTTag {
     }
 
     @Override
-    public boolean applyTo(NBTCompound nbtCompound, boolean onlyIfDifferent) {
+    public boolean applyToComp(Object nbtCompoundOpt, boolean onlyIfDifferent) {
+        NBTCompound nbtCompound = null;
+        if (SCore.hasNBTAPI) {
+            nbtCompound = (NBTCompound) nbtCompoundOpt;
+        } else return false;
+
         int integerValue = Integer.parseInt(StringPlaceholder.replaceRandomPlaceholders(String.valueOf(getValueInt())));
         if (!onlyIfDifferent || nbtCompound.getInteger(getKey()) != integerValue) {
             nbtCompound.setInteger(getKey(), integerValue);

--- a/src/main/java/com/ssomar/score/features/custom/nbttags/ListCompoundNBTTag.java
+++ b/src/main/java/com/ssomar/score/features/custom/nbttags/ListCompoundNBTTag.java
@@ -1,5 +1,6 @@
 package com.ssomar.score.features.custom.nbttags;
 
+import com.ssomar.score.SCore;
 import de.tr7zw.nbtapi.NBTCompound;
 import de.tr7zw.nbtapi.NBTCompoundList;
 import de.tr7zw.nbtapi.NBTListCompound;
@@ -36,7 +37,12 @@ ListCompoundNBTTag extends NBTTag {
     }
 
     @Override
-    public boolean applyTo(ReadWriteNBT nbtItem, boolean onlyIfDifferent) {
+    public boolean applyTo(Object nbtItemOpt, boolean onlyIfDifferent) {
+        ReadWriteNBT nbtItem = null;
+        if (SCore.hasNBTAPI) {
+            nbtItem = (ReadWriteNBT) nbtItemOpt;
+        } else return false;
+
         ReadWriteNBTCompoundList list = nbtItem.getCompoundList(getKey());
         //list.clear();
 
@@ -44,14 +50,19 @@ ListCompoundNBTTag extends NBTTag {
         for (CompoundNBTTag s : values) {
             ReadWriteNBT nbtListCompound = list.addCompound();
             for (NBTTag t : s.getNbtTags()) {
-                different = t.applyTo(nbtListCompound, onlyIfDifferent) || different;
+                different = t.applyToComp(nbtListCompound, onlyIfDifferent) || different;
             }
         }
         return different;
     }
 
     @Override
-    public boolean applyTo(NBTCompound nbtCompound, boolean onlyIfDifferent) {
+    public boolean applyToComp(Object nbtCompoundOpt, boolean onlyIfDifferent) {
+        NBTCompound nbtCompound = null;
+        if (SCore.hasNBTAPI) {
+            nbtCompound = (NBTCompound) nbtCompoundOpt;
+        } else return false;
+
         NBTCompoundList list = nbtCompound.getCompoundList(getKey());
         //list.clear();
 

--- a/src/main/java/com/ssomar/score/features/custom/nbttags/ListStringNBTTag.java
+++ b/src/main/java/com/ssomar/score/features/custom/nbttags/ListStringNBTTag.java
@@ -1,5 +1,6 @@
 package com.ssomar.score.features.custom.nbttags;
 
+import com.ssomar.score.SCore;
 import de.tr7zw.nbtapi.NBTCompound;
 import de.tr7zw.nbtapi.NBTList;
 import de.tr7zw.nbtapi.iface.ReadWriteNBT;
@@ -24,7 +25,12 @@ public class ListStringNBTTag extends NBTTag {
     }
 
     @Override
-    public boolean applyTo(ReadWriteNBT nbtItem, boolean onlyIfDifferent) {
+    public boolean applyTo(Object nbtItemOpt, boolean onlyIfDifferent) {
+        ReadWriteNBT nbtItem = null;
+        if (SCore.hasNBTAPI) {
+            nbtItem = (ReadWriteNBT) nbtItemOpt;
+        } else return false;
+
         ReadWriteNBTList<String> list = nbtItem.getStringList(getKey());
         //list.clear();
         boolean different = false;
@@ -37,7 +43,12 @@ public class ListStringNBTTag extends NBTTag {
     }
 
     @Override
-    public boolean applyTo(NBTCompound nbtCompound, boolean onlyIfDifferent) {
+    public boolean applyToComp(Object nbtCompoundOpt, boolean onlyIfDifferent) {
+        NBTCompound nbtCompound = null;
+        if (SCore.hasNBTAPI) {
+            nbtCompound = (NBTCompound) nbtCompoundOpt;
+        } else return false;
+
         NBTList<String> list = nbtCompound.getStringList(getKey());
         //list.clear();
         boolean different = false;

--- a/src/main/java/com/ssomar/score/features/custom/nbttags/NBTTag.java
+++ b/src/main/java/com/ssomar/score/features/custom/nbttags/NBTTag.java
@@ -1,10 +1,14 @@
 package com.ssomar.score.features.custom.nbttags;
 
-import de.tr7zw.nbtapi.NBTCompound;
-import de.tr7zw.nbtapi.iface.ReadWriteNBT;
 import lombok.Getter;
 import org.bukkit.configuration.ConfigurationSection;
 
+/**
+ * Base class for different types of nbt. <br/>
+ * <br/>
+ * The reason why the applyTo() and applyToComp() requires an {@code Object} class is because
+ * the original code directly utilizes classes from NBT API
+ */
 @Getter
 public abstract class NBTTag {
 
@@ -39,19 +43,19 @@ public abstract class NBTTag {
     /**
      * This method is used to apply nbt details to items. Will be more likely to be executed in cases such as
      * when you give yourself items via <code>/ei give</code>
-     * @param readWriteNbt
+     * @param readWriteNbt {@code de.tr7zw.nbtapi.iface.ReadWriteNBT}
      * @param onlyIfDifferent main executor's default value is {@code true}. It's to prevent accidental rewrite of nbt because previous reports complained about nbt getting shuffled around and having the wrong order
      * @return
      */
-    public abstract boolean applyTo(ReadWriteNBT readWriteNbt, boolean onlyIfDifferent);
+    public abstract boolean applyTo(Object readWriteNbt, boolean onlyIfDifferent);
 
     /**
      * This method is used mainly by ListCompoundNBT to write child nbt tags to items
-     * @param nbtCompound
+     * @param nbtCompound {@code de.tr7zw.nbtapi.NBTCompound}
      * @param onlyIfDifferent main executor's default value is {@code true}. It's to prevent accidental rewrite of nbt because previous reports complained about nbt getting shuffled around and having the wrong order
      * @return
      */
-    public abstract boolean applyTo(NBTCompound nbtCompound, boolean onlyIfDifferent);
+    public abstract boolean applyToComp(Object nbtCompound, boolean onlyIfDifferent);
 
     /**
      * When the user makes changes to the nbt list in the ingame editor or other ways, this method is called to save the changes to the item config.

--- a/src/main/java/com/ssomar/score/features/custom/nbttags/StringNBTTag.java
+++ b/src/main/java/com/ssomar/score/features/custom/nbttags/StringNBTTag.java
@@ -1,5 +1,6 @@
 package com.ssomar.score.features.custom.nbttags;
 
+import com.ssomar.score.SCore;
 import com.ssomar.score.utils.placeholders.StringPlaceholder;
 import de.tr7zw.nbtapi.NBTCompound;
 import de.tr7zw.nbtapi.iface.ReadWriteNBT;
@@ -23,7 +24,12 @@ public class StringNBTTag extends NBTTag {
     }
 
     @Override
-    public boolean applyTo(ReadWriteNBT nbtItem, boolean onlyIfDifferent) {
+    public boolean applyTo(Object nbtItemOpt, boolean onlyIfDifferent) {
+        ReadWriteNBT nbtItem = null;
+        if (SCore.hasNBTAPI) {
+            nbtItem = (ReadWriteNBT) nbtItemOpt;
+        } else return false;
+
         if (!onlyIfDifferent || !nbtItem.getString(getKey()).equals(getValueString())) {
             nbtItem.setString(getKey(), StringPlaceholder.replaceRandomPlaceholders(getValueString()));
             return true;
@@ -32,7 +38,12 @@ public class StringNBTTag extends NBTTag {
     }
 
     @Override
-    public boolean applyTo(NBTCompound nbtCompound, boolean onlyIfDifferent) {
+    public boolean applyToComp(Object nbtCompoundOpt, boolean onlyIfDifferent) {
+        NBTCompound nbtCompound = null;
+        if (SCore.hasNBTAPI) {
+            nbtCompound = (NBTCompound) nbtCompoundOpt;
+        } else return false;
+
         //SsomarDev.testMsg("StringNBTTag: " + getKey() + " " + getValueString(), true);
         if (!onlyIfDifferent || !nbtCompound.getString(getKey()).equals(getValueString())) {
             nbtCompound.setString(getKey(), getValueString());


### PR DESCRIPTION
For Ssomar to copypaste:
- Fixed an issue related to item configs having nbt entries and not having NBT API installed in your server

For Ssomar to read:
- This whole issue starts when you don't have nbt api plugin installed and then have at least one item config with a proper list compound nbt entry. Googled how a NoClassDef error could trigger and rechecked the code of the other nbt classes. Was surprised it didn't trip for this long