### PR TITLE
Modified checkers for ei id, usage and variables

### DIFF
--- a/src/main/java/com/ssomar/score/features/custom/itemcheckers/ItemCheckerEnum.java
+++ b/src/main/java/com/ssomar/score/features/custom/itemcheckers/ItemCheckerEnum.java
@@ -1,10 +1,16 @@
 package com.ssomar.score.features.custom.itemcheckers;
 
+import com.ssomar.score.SCore;
 import com.ssomar.score.features.FeatureSettingsInterface;
 import com.ssomar.score.features.FeatureSettingsSCore;
 import lombok.Getter;
+import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+
+import java.util.HashMap;
 
 public enum ItemCheckerEnum {
 
@@ -84,16 +90,68 @@ public enum ItemCheckerEnum {
                 return item1.getDurability() == item2.getDurability();
             case EXECUTABLEITEM_ID:
                 if(oneOfThemNaNoMeta) return bothNaNoMeta;
-                return item1Meta.getPersistentDataContainer().getKeys().equals(item2Meta.getPersistentDataContainer().getKeys());
+                String eiID1 = item1Meta.getPersistentDataContainer().get(new NamespacedKey("executableitems", "ei-id"), PersistentDataType.STRING);
+                String eiID2 = item2Meta.getPersistentDataContainer().get(new NamespacedKey("executableitems", "ei-id"), PersistentDataType.STRING);
+                if (eiID1 == null || eiID2 == null) return false;
+                return eiID1.equals(eiID2);
             case EXECUTABLEITEM_USAGE:
                 if(oneOfThemNaNoMeta) return bothNaNoMeta;
-                return item1Meta.getPersistentDataContainer().getKeys().equals(item2Meta.getPersistentDataContainer().getKeys());
+                Integer eiUsage1 = item1Meta.getPersistentDataContainer().get(new NamespacedKey("score", "usage"), PersistentDataType.INTEGER);
+                Integer eiUsage2 = item2Meta.getPersistentDataContainer().get(new NamespacedKey("score", "usage"), PersistentDataType.INTEGER);
+                if (eiUsage1 == null || eiUsage2 == null) return false;
+                return eiUsage1.equals(eiUsage2);
             case EXECUTABLEITEM_VARIABLES:
                 if(oneOfThemNaNoMeta) return bothNaNoMeta;
-                return item1Meta.getPersistentDataContainer().getKeys().equals(item2Meta.getPersistentDataContainer().getKeys());
+                // So far, ItemStack variables in PDC are written as: score:score-<var>
+                // And there's no formal way to specifically get those. I also don't wanna try using ExecutableItemObject because
+                // right now, it seems stupid to enforce the rule to loaded/valid ids only
+                try {
+                    return extractScoreVariables(item1Meta.getPersistentDataContainer())
+                            .equals(extractScoreVariables(item2Meta.getPersistentDataContainer()));
+                } catch (NullPointerException e) {
+                    return false;
+                }
                 
         }
         return false;
+    }
+
+    /**
+     * This method is for comparing the contents of 2 ItemStacks. Since EXECUTABLEITEM_VARIABLES only really care about
+     * item variables made from SCore, filter the pdc nbts accordingly.
+     * @param pdc
+     * @return
+     */
+    private HashMap<NamespacedKey, Object> extractScoreVariables(PersistentDataContainer pdc) {
+        HashMap<NamespacedKey, Object> variables = new HashMap<>();
+        for (NamespacedKey key : pdc.getKeys()) {
+            if (key.toString().startsWith("score:score-")) {
+                variables.put(key, tryToGetObjectFromPDC(pdc, key));
+            }
+        }
+        return variables;
+    }
+
+    /**
+     * You can get the keys of the PDC but you can't know the datatype of the value pairs
+     * so the best option is to make attempts in guessing the datatype.
+     * <br/><br/>
+     * ItemStack variables only come in STRING, DOUBLE and STRING_ARRAY and nothing more
+     * @param pdc
+     * @return
+     */
+    private Object tryToGetObjectFromPDC(PersistentDataContainer pdc, NamespacedKey key) {
+        if (pdc.has(key, PersistentDataType.STRING))
+            return pdc.get(key, PersistentDataType.STRING);
+        if (pdc.has(key, PersistentDataType.DOUBLE))
+            return pdc.get(key, PersistentDataType.DOUBLE);
+        if (pdc.has(key, PersistentDataType.LIST.strings()))
+            return pdc.get(key, PersistentDataType.LIST.strings());
+
+        // Will never be reached but just in case
+        SCore.plugin.getLogger().warning("[!] A line in ItemCheckerEnum for SCore has been reached but not meant to. Contact Special70 about this.");
+        SCore.plugin.getLogger().warning("[!] NamespacedKey => "+key.toString());
+        return null;
     }
 
 }


### PR DESCRIPTION
- Had to put proper logic in its place instead of what was written previously because it only compares pdc values which is BAD for edge cases such as if the other copy has other nbts in the pdc
- Performed basic tests and found no issues

Copypaste for changelog
- Fixed an issue with the checker logic used by ExecutableCrafting. Checkers for EI ID, EI Usage and EI Variables should be ok now