### PR TITLE
Properly modified defaults for MLIB_DAMAGE

### DIFF
--- a/src/main/java/com/ssomar/score/commands/runnable/mixed_player_entity/commands/MLibDamage.java
+++ b/src/main/java/com/ssomar/score/commands/runnable/mixed_player_entity/commands/MLibDamage.java
@@ -33,7 +33,7 @@ public class MLibDamage extends MixedCommand {
         CommandSetting damage = new CommandSetting("damage", 0, String.class, 10);
         CommandSetting type = new CommandSetting("type", 1, String.class, "PHYSICAL");
         CommandSetting knockback = new CommandSetting("knockback", 2, Boolean.class, false);
-        CommandSetting element = new CommandSetting("element", 3, String.class, "FIRE");
+        CommandSetting element = new CommandSetting("element", 3, String.class, "NULL");
         CommandSetting crit = new CommandSetting("crit", 4, Boolean.class, false);
         List<CommandSetting> settings = getSettings();
         settings.add(damage);

--- a/src/main/java/com/ssomar/score/usedapi/MyhticLibAPI.java
+++ b/src/main/java/com/ssomar/score/usedapi/MyhticLibAPI.java
@@ -30,7 +30,8 @@ public class MyhticLibAPI {
     public static void mlib_damage(@Nullable LivingEntity attacker, LivingEntity entity, double damageInput, String damageType, @Nullable String element, boolean knockback, boolean crit) {
 
         Element elementEnum = null;
-        if (element != null){
+        assert element != null; // Default: "NULL"
+        if (!element.equals("NULL")){
             try {
                 elementEnum = Element.valueOf(element);
             } catch (IllegalArgumentException e) {


### PR DESCRIPTION
Element type for MLIB_DAMAGE should now be able to receive NULL as element type to make the MLIB_DAMAGE deal non-elemental damage