### PR TITLE
fix: clear player editor state on quit; fix missing cleanup in receiveMessageFinish

### DIFF
--- a/src/main/java/com/ssomar/score/editor/NewGUIManager.java
+++ b/src/main/java/com/ssomar/score/editor/NewGUIManager.java
@@ -69,6 +69,13 @@ public abstract class NewGUIManager<T extends GUI> {
         suggestionPage.remove(player);
     }
 
+    public void clearPlayerEditorState(Player player) {
+        requestWriting.remove(player);
+        currentWriting.remove(player);
+        suggestions.remove(player);
+        disableTextEditor(player);
+    }
+
     public void clicked(Player p, ItemStack item, ClickType click) {
         NewInteractionClickedGUIManager<T> interact = new NewInteractionClickedGUIManager<>();
         interact.player = p;

--- a/src/main/java/com/ssomar/score/features/editor/FeatureEditorManagerAbstract.java
+++ b/src/main/java/com/ssomar/score/features/editor/FeatureEditorManagerAbstract.java
@@ -342,6 +342,9 @@ public abstract class FeatureEditorManagerAbstract<T extends FeatureEditorInterf
             if (feature instanceof FeatureRequireMultipleMessageInEditor) {
                 if (feature.getEditorName().equals(requestWriting.get(interact.player))) {
                     ((FeatureRequireMultipleMessageInEditor) feature).finishEditInEditor(interact.player, this, null);
+                    currentWriting.remove(interact.player);
+                    requestWriting.remove(interact.player);
+                    disableTextEditor(interact.player);
                     interact.gui.openGUISync(interact.player);
                 }
             } else if (feature instanceof FeatureRequireSubTextEditorInEditor) {


### PR DESCRIPTION
## Summary

- **Add `clearPlayerEditorState(Player)`** to `NewGUIManager`: atomically removes a player from `requestWriting`, `currentWriting`, `suggestions`, and text-editor maps in a single call
- **Fix `receiveMessageFinish`**: the `FeatureRequireMultipleMessageInEditor` branch was missing `requestWriting.remove()`, `currentWriting.remove()`, and `disableTextEditor()` — chat remained stuck after the player typed "exit" for any feature using that interface

## Root cause

`requestWriting` maps a player to the feature they are currently editing via chat. If this entry is never cleared (player quits, or `FeatureRequireMultipleMessageInEditor` finishes without cleanup), every subsequent chat message is intercepted by the editor, making normal chat impossible until relog.

## Test plan

- [ ] Open EI GUI, enter text-editor mode for trigger commands, quit server — after relog the player can chat normally
- [ ] Open EI GUI, enter text-editor mode, then open any other inventory — editor state is cleared and chat works
- [ ] Normal "exit" flow still works: typing "exit" or clicking [FINISH] completes the edit and reopens the GUI

## Related

Depends on the companion fix in **ExecutableItems** (`fix/chat-stuck-editor-state`) which adds `PlayerQuitEvent` and `InventoryOpenEvent` handlers that call this new `clearPlayerEditorState` method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)