### PR TITLE
fix: render item name as colored value in give/full-inventory messages

### DIFF
--- a/src/main/java/com/ssomar/score/commands/score/GiveCommand.java
+++ b/src/main/java/com/ssomar/score/commands/score/GiveCommand.java
@@ -233,7 +233,7 @@ public class GiveCommand<X extends SPlugin, Y extends SObjectManager<Z>, Z exten
             quantity = quantity - maxStack;
         }
         if (outInventory > 0) {
-            getSm().sendMessage(player, StringConverter.replaceVariable(MessageMain.getInstance().getMessage(getSPlugin().getPlugin(), Message.FULL_INVENTORY), player.getName(), object.getItemName(), outInventory + "", 0));
+            getSm().sendMessage(player, StringConverter.replaceVariable(MessageMain.getInstance().getMessage(getSPlugin().getPlugin(), Message.FULL_INVENTORY), player.getName(), StringConverter.coloredString(object.getItemName()), outInventory + "", 0));
             inInventory = inInventory - outInventory;
         }
 
@@ -244,7 +244,7 @@ public class GiveCommand<X extends SPlugin, Y extends SObjectManager<Z>, Z exten
         }
 
         if (!getSPlugin().getPluginConfig().getBooleanSetting("silentGive"))
-            getSm().sendMessage(player, StringConverter.replaceVariable(MessageMain.getInstance().getMessage(getSPlugin().getPlugin(), Message.RECEIVE_ITEM), player.getName(), object.getItemName(), inInventory + "", 0));
+            getSm().sendMessage(player, StringConverter.replaceVariable(MessageMain.getInstance().getMessage(getSPlugin().getPlugin(), Message.RECEIVE_ITEM), player.getName(), StringConverter.coloredString(object.getItemName()), inInventory + "", 0));
     }
 
 


### PR DESCRIPTION
GiveCommand passed the raw display-name value (getItemName() -> getDisplayName().getValue()) into the RECEIVE_ITEM and FULL_INVENTORY messages. When the name used MiniMessage tags, the raw tags were embedded into a legacy-coded locale template; SendMessage could not parse the mixed string, so the MiniMessage brackets showed as literal text while translateHexCodes turned the inner hex into a legacy color.

Wrap the name in StringConverter.coloredString(...) so the message path renders the name exactly like the item itself (getColoredValue), keeping both paths identical.