### PR TITLE
Fix tick lag: skip WINDOW_ITEMS display rebuild when nothing to modify

### DIFF
--- a/src/main/java/com/ssomar/score/utils/display/PacketManager.java
+++ b/src/main/java/com/ssomar/score/utils/display/PacketManager.java
@@ -21,6 +21,13 @@ public class PacketManager {
         SCore.protocolManager.addPacketListener(new PacketAdapter(params) {
             @Override
             public void onPacketSending(PacketEvent event) {
+                /* If no display module has loaded IDs, no item can be modified:
+                 * skip the expensive per-item rebuild (item clone + inventory scan).
+                 * Same guard as the repeating refresh task in SCore (Display.isSomethingToModify()).
+                 * Fixes lag with plugins that resend inventories/items in packets
+                 * (e.g. InteractiveChat [item]) https://discord.com/channels/701066025516531753/1522499028795916310 */
+                if (!Display.isSomethingToModify()) return;
+
                 PacketContainer packet = event.getPacket();
 
                 /* if (event.getPacketType() == PacketType.Play.Server.SET_SLOT && event.getPlayer().getGameMode() != GameMode.CREATIVE) {


### PR DESCRIPTION
## Problem

When players use InteractiveChat's `[item]` feature to show an item in chat, the server lags heavily (ticks >300ms in the profiler).

Discord report: https://discord.com/channels/701066025516531753/1522499028795916310

## Root cause

The ProtocolLib `WINDOW_ITEMS` packet listener in `PacketManager.newDisplay()` calls `Display.display(item, player)` for **every item of every inventory packet**, unconditionally. Each call clones the item and runs `inventory.contains(original)` (a deep ItemStack-equality scan over the whole player inventory), so a single 46-slot packet costs dozens of clones and hundreds of meta comparisons — even when **no display module has anything loaded** and the result can only ever be `NOT_MODIFIED`.

Plugins like InteractiveChat trigger these inventory packets very frequently, which turns this into major tick lag.

The cheap guard for this already exists — `Display.isSomethingToModify()` (true only when at least one registered display module has loaded IDs, i.e. at least one item with display conditions exists) — but it was only applied to the repeating inventory refresh task in `SCore.java`, not to the packet listener.

## Fix

Apply the same `Display.isSomethingToModify()` guard at the top of the packet listener's `onPacketSending`, so servers with no display-condition items skip the per-item rebuild entirely. Behavior is unchanged when display conditions are in use.

## Testing

- Built with `mvn -DskipTests package` (JDK 25): success.
- Guard semantics verified against the existing refresh-task usage (`SCore.java`, `Runnable runnable3`) and `DisplayModule.getLoadedIDs()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)