### PR TITLE
Fix NoSuchMethodError in BlocksAttacksFeatures.loadFromItem — crashes /ei create with shields on 1.21.x

### DIFF
--- a/src/main/java/com/ssomar/score/features/custom/blocksAttacksFeatures/BlocksAttacksFeatures.java
+++ b/src/main/java/com/ssomar/score/features/custom/blocksAttacksFeatures/BlocksAttacksFeatures.java
@@ -188,12 +188,22 @@ public class BlocksAttacksFeatures extends FeatureWithHisOwnEditor<BlocksAttacks
                 BlocksAttacks blocksAttacks = item.getData(DataComponentTypes.BLOCKS_ATTACKS);
                 enable.setValue(true);
                 blockDelay.setValue(Optional.of((int) blocksAttacks.blockDelaySeconds()));
-                blockSound.setValue(Optional.ofNullable(SoundUtils.getSound(blocksAttacks.blockSound().value())));
-                disableSound.setValue(Optional.ofNullable(SoundUtils.getSound(blocksAttacks.disableSound().value())));
+                // blockSound() / disableSound() are nullable (e.g. custom blocks_attacks components without sounds)
+                net.kyori.adventure.key.Key blockSoundKey = blocksAttacks.blockSound();
+                blockSound.setValue(blockSoundKey == null ? Optional.empty() : Optional.ofNullable(SoundUtils.getSound(blockSoundKey.value())));
+                net.kyori.adventure.key.Key disableSoundKey = blocksAttacks.disableSound();
+                disableSound.setValue(disableSoundKey == null ? Optional.empty() : Optional.ofNullable(SoundUtils.getSound(disableSoundKey.value())));
                 disableCooldownScale.setValue(Optional.of((double) blocksAttacks.disableCooldownScale()));
                 damageReductions.setValues(blocksAttacks.damageReductions());
-                // bypassedBy() returns RegistryKeySet on new Paper, TagKey on old Paper
-                Object bypassedByValue = blocksAttacks.bypassedBy();
+                // bypassedBy() returns RegistryKeySet on new Paper, TagKey on old Paper (1.21.5 - 1.21.x).
+                // The return type is part of the compiled method descriptor, so a direct call compiled against
+                // one API throws NoSuchMethodError on the other -> it must be invoked via reflection.
+                Object bypassedByValue = null;
+                try {
+                    bypassedByValue = BlocksAttacks.class.getMethod("bypassedBy").invoke(blocksAttacks);
+                } catch (Exception e) {
+                    SsomarDev.testMsg("Could not read bypassedBy from the blocks_attacks component: " + e.getMessage(), true);
+                }
                 if (bypassedByValue instanceof io.papermc.paper.registry.set.RegistryKeySet) {
                     bypassedBy.setValue((io.papermc.paper.registry.set.RegistryKeySet<DamageType>) bypassedByValue);
                 } else if (bypassedByValue instanceof io.papermc.paper.registry.tag.TagKey) {


### PR DESCRIPTION
## Problem
`/ei create <id>` while holding a **SHIELD** throws an unhandled exception on 1.21.x servers (reported on Purpur 1.21.8, reproduced on Paper 1.21.11), making it impossible to turn shields into ExecutableItems:

```
org.bukkit.command.CommandException: Unhandled exception executing command 'ei' in plugin ExecutableItems
Caused by: java.lang.NoSuchMethodError: 'io.papermc.paper.registry.set.RegistryKeySet io.papermc.paper.datacomponent.item.BlocksAttacks.bypassedBy()'
	at com.ssomar.score.features.custom.blocksAttacksFeatures.BlocksAttacksFeatures.loadFromItem(BlocksAttacksFeatures.java:196)
	at com.ssomar.executableitems.executableitems.ItemStackToExecutableItemConverter.convert(ItemStackToExecutableItemConverter.java:50)
```

Discord report: https://discord.com/channels/701066025516531753/1523600199178784799

## Root cause
`BlocksAttacks#bypassedBy()` changed its return type between Paper versions:
- Paper 1.21.5 – 1.21.x: `TagKey<DamageType>`
- Newer Paper (26.x, which SCore compiles against): `RegistryKeySet<DamageType>`

The return type is part of the compiled method descriptor, so the direct call in `loadFromItem` (compiled against the 26.x API) throws `NoSuchMethodError` at the call site on 1.21.x servers — the existing `instanceof` dual-handling below it never gets a chance to run. Every shield carries a default `minecraft:blocks_attacks` component, so **every** shield hit this path.

Note: the apply path (`applyOnItem`) already worked around the same API change with a reflection fallback for the builder; the load path was missed.

## Fix
- Invoke `bypassedBy()` via reflection through the `BlocksAttacks` interface (`BlocksAttacks.class.getMethod("bypassedBy").invoke(...)`) — reflection dispatch ignores the return type, so the same jar works on both API variants; the existing `instanceof TagKey / RegistryKeySet` handling then applies.
- Null-guard `blockSound()` / `disableSound()`, which are nullable for `blocks_attacks` components without sounds (EI itself produces such components when no sound is configured), preventing the same command from NPE-ing on those items.

## Verification
Reproduced the exact crash on a local Paper 1.21.11 test server, then with this fix:
- `/ei create Samurai_Shield` while holding a shield completes and creates the config,
- the vanilla shield component imports correctly (`blockSound: ITEM.SHIELD.BLOCK`, `disableSound: ITEM.SHIELD.BREAK`, damage reductions, delay),
- `/ei give` of the created item works.

Companion PR in ExecutableItems makes the converter skip a failing feature instead of aborting the whole command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)