### PR TITLE
Fix players stuck unable to right-click entities until restart (stale SEvents interaction markers)

### DIFF
--- a/src/main/java/com/ssomar/score/events/EventsHandler.java
+++ b/src/main/java/com/ssomar/score/events/EventsHandler.java
@@ -42,6 +42,12 @@ public class EventsHandler {
 
         main.getServer().getPluginManager().registerEvents(new PlayerQuitListener(), main);
 
+        /* Self-healing cleanup of the SEvents per-player interaction markers
+         * (stuck entries made some players unable to right click entities until restart) */
+        SEventsStuckInteractionCleaner sEventsStuckInteractionCleaner = new SEventsStuckInteractionCleaner();
+        main.getServer().getPluginManager().registerEvents(sEventsStuckInteractionCleaner, main);
+        sEventsStuckInteractionCleaner.startSweepTask();
+
         /* No EntityToggleGlideEvent & EntityPickupItemEvent in 1.11 -*/
         if (!SCore.is1v11Less()) {
             main.getServer().getPluginManager().registerEvents(new StunEvent(), main);

--- a/src/main/java/com/ssomar/score/events/SEventsStuckInteractionCleaner.java
+++ b/src/main/java/com/ssomar/score/events/SEventsStuckInteractionCleaner.java
@@ -1,0 +1,89 @@
+package com.ssomar.score.events;
+
+import com.ssomar.score.SCore;
+import com.ssomar.sevents.events.player.click.CancelOffHandInteractionManager;
+import com.ssomar.sevents.events.player.click.TooManyInteractionManager;
+import com.ssomar.sevents.events.player.click.TransmitCancelInteractionManager;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Self-healing cleanup for the per-player interaction markers of SEvents
+ * ({@link TransmitCancelInteractionManager}, {@link CancelOffHandInteractionManager},
+ * {@link TooManyInteractionManager}).
+ *
+ * Those static maps are used to transmit a cancellation from one native event of a click
+ * to the other native events of the SAME click (PlayerInteractAtEntityEvent -&gt;
+ * PlayerInteractEntityEvent, main hand -&gt; off hand, ...). They are only meaningful for a
+ * few ticks, but nothing ever removed the entries when the follow-up packet never arrives
+ * (armor stands consume interactAt client side so no INTERACT packet follows, empty
+ * off-hand air clicks send no off-hand event, Bedrock/Geyser players never send off-hand
+ * interactions, another plugin pre-cancels the event, ...).
+ *
+ * A stale entry then cancels a future, unrelated entity interaction of that player
+ * (and can get re-seeded in a loop), which made some players unable to right click
+ * entities until a full server restart, see:
+ * https://discord.com/channels/701066025516531753/1516845050590400582
+ * https://discord.com/channels/701066025516531753/1524291528938492105
+ *
+ * This class:
+ * - removes the markers of a player when he disconnects (a relog now always fixes the state)
+ * - purges, with a two-generation sweep, any marker that survived a full sweep period
+ *   (entries live at most ~2s instead of forever), which also self-heals any stuck path
+ *   we don't know about yet.
+ */
+public class SEventsStuckInteractionCleaner implements Listener {
+
+    /* 20 ticks: a marker is only valid inside a single click (same tick or the next ones
+     * under heavy lag), so 1-2 seconds of lifetime is already very generous. */
+    private static final long SWEEP_PERIOD_TICKS = 20L;
+
+    private final Set<UUID> transmitCancelPreviousGen = new HashSet<>();
+    private final Set<UUID> cancelOffHandPreviousGen = new HashSet<>();
+    private final Set<UUID> tooManyPreviousGen = new HashSet<>();
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onPlayerQuit(PlayerQuitEvent e) {
+        UUID uuid = e.getPlayer().getUniqueId();
+        TransmitCancelInteractionManager.getInstance().remove(uuid);
+        CancelOffHandInteractionManager.getInstance().remove(uuid);
+        TooManyInteractionManager.getInstance().remove(uuid);
+        transmitCancelPreviousGen.remove(uuid);
+        cancelOffHandPreviousGen.remove(uuid);
+        tooManyPreviousGen.remove(uuid);
+    }
+
+    public void startSweepTask() {
+        SCore.schedulerHook.runRepeatingTask(this::sweep, SWEEP_PERIOD_TICKS, SWEEP_PERIOD_TICKS);
+    }
+
+    private void sweep() {
+        sweep(TransmitCancelInteractionManager.getInstance(), transmitCancelPreviousGen);
+        sweep(CancelOffHandInteractionManager.getInstance(), cancelOffHandPreviousGen);
+        sweep(TooManyInteractionManager.getInstance(), tooManyPreviousGen);
+    }
+
+    /**
+     * Two-generation sweep: an entry still present since the previous sweep is stale
+     * (older than one full period) and gets removed. Fresh entries (added since the last
+     * sweep) are kept for one more period, so a click in progress is never affected.
+     */
+    private void sweep(Map<UUID, Integer> map, Set<UUID> previousGen) {
+        if (map.isEmpty()) {
+            previousGen.clear();
+            return;
+        }
+        for (UUID uuid : new HashSet<>(map.keySet())) {
+            if (previousGen.contains(uuid)) map.remove(uuid);
+        }
+        previousGen.clear();
+        previousGen.addAll(map.keySet());
+    }
+}


### PR DESCRIPTION
## Symptom

Two independent reports (EI ~7.26.5.31 / 7.26.7.5, Paper/Purpur 1.21.x):
- https://discord.com/channels/701066025516531753/1516845050590400582
- https://discord.com/channels/701066025516531753/1524291528938492105

Some players randomly become unable to right-click/interact with **any** entity (and interactive items). The state survives relogs and only a **server restart** fixes it. An EventDebugger showed **ExecutableItems** cancelling `PlayerInteractAtEntityEvent` on every right-click of an affected player.

## Root cause

EI itself never cancels `PlayerInteractAtEntityEvent` unconditionally — the cancel comes from the **SEvents** listeners bundled in SCore and registered under the ExecutableItems plugin via `DynamicRegistration` (which is why the EventDebugger blames EI).

`PlayerRightClickOnEntityListener` / `PlayerRightClickListener` use three **static, never-expiring** `HashMap<UUID, Integer>` singletons to transmit a cancellation between the native events of a *single* click:

- `TransmitCancelInteractionManager` (TC) — put at `PlayerRightClickOnEntityListener.java:44,56`, consumed+cancels at `:90-93` (next `PlayerInteractEntityEvent`)
- `CancelOffHandInteractionManager` (COH) — put at `PlayerRightClickOnEntityListener.java:72` and `PlayerRightClickListener.java:92`, consumed+cancels at `PlayerRightClickOnEntityListener.java:41-44` and `PlayerRightClickListener.java:66-69`
- `TooManyInteractionManager` — same pattern for the synthetic left-clicks

The entries are only removed by the follow-up event of the same click — which frequently **never arrives**:

- **armor stands**: the vanilla client consumes `interactAt` client-side, so no `INTERACT` packet (and no off-hand attempt) ever follows → TC + COH stay stuck after a cancelled armor-stand click
- **cancelled right-click on air with an empty off hand** (typical “wand” EI with `cancelEvent: true`): no off-hand `PlayerInteractEvent` follows → COH stays stuck
- **Bedrock/Geyser players** never send off-hand interactions → COH is never consumed
- events **pre-cancelled by another plugin** are mirrored into the custom event (`playerRightClickOnEntityEvent.setCancelled(e.isCancelled())`, `PlayerRightClickOnEntityListener.java:51`) and re-seed TC/COH on every click, keeping the loop alive

A stale entry then cancels a future, **unrelated** `PlayerInteractEntityEvent` / `PlayerInteractAtEntityEvent` of that player (villager trades, NPC shops, item frames…) and can keep re-seeding itself. Nothing ever cleared the maps — not even on `PlayerQuitEvent` — so relogging didn’t help and only a restart (static state wiped) did. This matches every reported detail: random players only, any entity, any hand item, restart-only.

## Fix (self-healing, covers unknown paths too)

SEvents is consumed as a pinned artifact, so the fix lives in SCore, which already links against those singleton maps:

New `SEventsStuckInteractionCleaner` (registered in `EventsHandler`):

1. **`PlayerQuitEvent` (MONITOR)** — removes the player’s markers from all three maps → a relog now always heals the player.
2. **Two-generation sweep every 20 ticks** — any marker that survived one full sweep period (i.e. older than ~1s, while the markers are only meaningful within a single click / a few ticks) is purged. Fresh markers always survive at least one full period, so a click in progress is never affected. This self-heals *every* stuck path, including ones not identified yet.

Worst-case trade-off: an intentionally cancelled interaction whose follow-up packet arrives more than a second later (extreme lag) would not have its cancel transmitted once — vastly better than players being permanently unable to interact.

## Build

`mvn -DskipTests package` with JDK 25: ✅ success (`SCore-42.42.42.jar`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)