### PR TITLE
fix(weapons): restore configured sound on item load (round-trip)

### DIFF
--- a/src/main/java/com/ssomar/score/features/custom/kineticWeaponFeatures/KineticWeaponFeatures.java
+++ b/src/main/java/com/ssomar/score/features/custom/kineticWeaponFeatures/KineticWeaponFeatures.java
@@ -12,6 +12,7 @@ import com.ssomar.score.features.types.SoundFeature;
 import com.ssomar.score.menu.GUI;
 import com.ssomar.score.splugin.SPlugin;
 import com.ssomar.score.utils.backward_compatibility.SoundUtils;
+import net.kyori.adventure.key.Key;
 import com.ssomar.score.utils.emums.ResetSetting;
 import com.ssomar.score.utils.logging.Utils;
 import com.ssomar.score.utils.strings.StringConverter;
@@ -233,8 +234,14 @@ public class KineticWeaponFeatures extends FeatureWithHisOwnEditor<KineticWeapon
                 loadCondition(kineticWeapon.dismountConditions(), dismountMaxDurationTicks, dismountMinSpeed, dismountMinRelativeSpeed);
                 loadCondition(kineticWeapon.knockbackConditions(), knockbackMaxDurationTicks, knockbackMinSpeed, knockbackMinRelativeSpeed);
                 loadCondition(kineticWeapon.damageConditions(), damageMaxDurationTicks, damageMinSpeed, damageMinRelativeSpeed);
-                enableSound.setValue(kineticWeapon.sound() != null);
-                enableHitSound.setValue(kineticWeapon.hitSound() != null);
+                Key soundKey = kineticWeapon.sound();
+                enableSound.setValue(soundKey != null);
+                Sound loadedSound = SoundUtils.getSoundFromKey(soundKey);
+                if (loadedSound != null) sound.setValue(Optional.of(loadedSound));
+                Key hitSoundKey = kineticWeapon.hitSound();
+                enableHitSound.setValue(hitSoundKey != null);
+                Sound loadedHitSound = SoundUtils.getSoundFromKey(hitSoundKey);
+                if (loadedHitSound != null) hitSound.setValue(Optional.of(loadedHitSound));
             }
         }
     }

--- a/src/main/java/com/ssomar/score/features/custom/piercingWeaponFeatures/PiercingWeaponFeatures.java
+++ b/src/main/java/com/ssomar/score/features/custom/piercingWeaponFeatures/PiercingWeaponFeatures.java
@@ -10,6 +10,7 @@ import com.ssomar.score.features.types.SoundFeature;
 import com.ssomar.score.menu.GUI;
 import com.ssomar.score.splugin.SPlugin;
 import com.ssomar.score.utils.backward_compatibility.SoundUtils;
+import net.kyori.adventure.key.Key;
 import com.ssomar.score.utils.emums.ResetSetting;
 import com.ssomar.score.utils.logging.Utils;
 import com.ssomar.score.utils.strings.StringConverter;
@@ -167,8 +168,14 @@ public class PiercingWeaponFeatures extends FeatureWithHisOwnEditor<PiercingWeap
                 enable.setValue(true);
                 dealsKnockback.setValue(piercingWeapon.dealsKnockback());
                 dismounts.setValue(piercingWeapon.dismounts());
-                enableSound.setValue(piercingWeapon.sound() != null);
-                enableHitSound.setValue(piercingWeapon.hitSound() != null);
+                Key soundKey = piercingWeapon.sound();
+                enableSound.setValue(soundKey != null);
+                Sound loadedSound = SoundUtils.getSoundFromKey(soundKey);
+                if (loadedSound != null) sound.setValue(Optional.of(loadedSound));
+                Key hitSoundKey = piercingWeapon.hitSound();
+                enableHitSound.setValue(hitSoundKey != null);
+                Sound loadedHitSound = SoundUtils.getSoundFromKey(hitSoundKey);
+                if (loadedHitSound != null) hitSound.setValue(Optional.of(loadedHitSound));
             }
         }
     }

--- a/src/main/java/com/ssomar/score/utils/backward_compatibility/SoundUtils.java
+++ b/src/main/java/com/ssomar/score/utils/backward_compatibility/SoundUtils.java
@@ -42,6 +42,19 @@ public class SoundUtils {
         return MapUtil.sortByValue(list);
     }
 
+    /**
+     * Resolve the org.bukkit.Sound matching an Adventure key (as returned by the
+     * item data-component API, e.g. PiercingWeapon#sound()). Returns null if the
+     * key is null or no matching sound exists.
+     */
+    public static Sound getSoundFromKey(net.kyori.adventure.key.Key key) {
+        if (key == null) return null;
+        if (SCore.is1v21v2Plus()) {
+            return Registry.SOUNDS.get(new NamespacedKey(key.namespace(), key.value()));
+        }
+        return getSound(key.value());
+    }
+
     public static Sound getSound(String string) {
         string = string.replace("minecraft:", "");
         for(Map.Entry<Object, String> entry : getSounds().entrySet()) {


### PR DESCRIPTION
Follow-up to #198. `loadFromItem` in PiercingWeaponFeatures/KineticWeaponFeatures set only the `enableSound`/`enableHitSound` toggles but never copied the component's actual sound back into the `sound`/`hitSound` features — so re-reading an existing item into the editor silently reset the configured sound to the default.

Adds `SoundUtils#getSoundFromKey(Key)` (maps the data-component Adventure key back to an `org.bukkit.Sound` via `Registry.SOUNDS`, version-guarded) and uses it in both `loadFromItem` methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)