### PR TITLE
Improved IF logic to handle single | and &

### DIFF
--- a/src/main/java/com/ssomar/score/commands/runnable/player/commands/If.java
+++ b/src/main/java/com/ssomar/score/commands/runnable/player/commands/If.java
@@ -90,8 +90,11 @@ public class If extends PlayerCommand {
             // If current char is part of a condition, extract and evaluate it
             else {
                 StringBuilder cond = new StringBuilder();
-                while (i < condition.length() && condition.charAt(i) != '(' && condition.charAt(i) != ')' && condition.charAt(i) != '&' && condition.charAt(i) != '|') {
-                    //SsomarDev.testMsg(" IF parsing condition at index <" + i + "> <" + condition.charAt(i)+">", true);
+                while (i < condition.length() && condition.charAt(i) != '(' && condition.charAt(i) != ')' && condition.charAt(i) != '&') {
+                    // SCore's %rand% placeholder uses '|' to separate number ranges, so extra logic is required to properly detect "||" and "&&" char sequences
+                    if (i+1 < condition.length() && (condition.substring(i, i+2).equals("||") || condition.substring(i, i+2).equals("&&"))) {
+                        break;
+                    }
                     cond.append(condition.charAt(i));
                     i++;
                 }

--- a/src/main/java/com/ssomar/score/commands/runnable/player/commands/If.java
+++ b/src/main/java/com/ssomar/score/commands/runnable/player/commands/If.java
@@ -92,7 +92,10 @@ public class If extends PlayerCommand {
                 StringBuilder cond = new StringBuilder();
                 while (i < condition.length() && condition.charAt(i) != '(' && condition.charAt(i) != ')' && condition.charAt(i) != '&') {
                     // SCore's %rand% placeholder uses '|' to separate number ranges, so extra logic is required to properly detect "||" and "&&" char sequences
-                    if (i+1 < condition.length() && (condition.substring(i, i+2).equals("||") || condition.substring(i, i+2).equals("&&"))) {
+                    char c = condition.charAt(i);
+                    char next = (i + 1 < condition.length()) ? condition.charAt(i + 1) : '\0';
+
+                    if ((c == '|' && next == '|') || (c == '&' && next == '&')) {
                         break;
                     }
                     cond.append(condition.charAt(i));


### PR DESCRIPTION
- Mainly to support rand plchs of SCore so conditions like `IF %rand:1|2%=2` would work

The issue with the logic is that it cuts off any | or & symbols instead of verifying whether if it's really a || or a &&. Will throw an exception if the condition is like `IF 2||` but that's something else entirely