### PR TITLE
Hermes cycle 2026-08: 4 bug fixes from Discord reports

### DIFF
--- a/src/main/java/com/ssomar/score/SCore.java
+++ b/src/main/java/com/ssomar/score/SCore.java
@@ -835,6 +835,7 @@ public final class SCore extends JavaPlugin implements SPlugin {
 
         Utils.sendConsoleMsg(SCore.NAME_COLOR + " &7Clear scheduled tasks...");
         ScheduledTaskManager.getInstance().cancelScheduledTask();
+        LoopManager.getInstance().shutdown();
         Utils.sendConsoleMsg(SCore.NAME_COLOR + " &7Clear scheduled tasks done !");
 
         // Unregister all packs

--- a/src/main/java/com/ssomar/score/commands/runnable/block/commands/Around.java
+++ b/src/main/java/com/ssomar/score/commands/runnable/block/commands/Around.java
@@ -19,7 +19,6 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 
 /* AROUND {distance} {true or false} {Your commands here} */
@@ -46,24 +45,6 @@ public class Around extends BlockCommand {
     }
 
     @Override
-    public Optional<String> verify(List<String> args, boolean isFinalVerification) {
-        String error = "";
-
-        String around = "AROUND {distance} [affectThePlayerThatActivesTheActivator true or false] {Your commands here}";
-
-        if (args.size() < 2) error = notEnoughArgs + around;
-        else if (args.size() > 2) {
-            try {
-                Double.valueOf(args.get(0));
-            } catch (NumberFormatException e) {
-                error = invalidDistance + args.get(0) + " for command: " + around;
-            }
-        }
-
-        return error.isEmpty() ? Optional.empty() : Optional.of(error);
-    }
-
-    @Override
     public List<String> getNames() {
         List<String> names = new ArrayList<>();
         names.add("AROUND");
@@ -72,7 +53,7 @@ public class Around extends BlockCommand {
 
     @Override
     public String getTemplate() {
-        return "AROUND {distance} [affectThePlayerThatActivesTheActivator true or false] {Your commands here}";
+        return "AROUND distance:3.0 affectThePlayerThatActivesTheActivator:true throughBlocks:true limit:-1 sort:NEAREST regionCheck:false {Your commands here}";
     }
 
     @Override

--- a/src/main/java/com/ssomar/score/events/loop/LoopManager.java
+++ b/src/main/java/com/ssomar/score/events/loop/LoopManager.java
@@ -8,10 +8,13 @@ import com.ssomar.score.sobject.sactivator.EventInfo;
 import com.ssomar.score.sobject.sactivator.OptionGlobal;
 import com.ssomar.score.splugin.SPlugin;
 import com.ssomar.score.usedapi.Dependency;
+import com.ssomar.score.utils.scheduler.ScheduledTask;
 import lombok.Getter;
 import org.bukkit.plugin.Plugin;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 
 public class LoopManager {
@@ -23,6 +26,7 @@ public class LoopManager {
     private final Map<SActivator, Integer> loopActivators;
     private final List<SActivator> loopActivatorsToAdd;
     private final List<SActivator> loopActivatorsToRemove;
+    private ScheduledTask loopTask;
 
     public LoopManager(Plugin plugin) {
         // If SCore is installed, use it as the plugin otherwise use the provided plugin (probably a plugin that shades SCore)
@@ -31,9 +35,9 @@ public class LoopManager {
         DELAY = 5;
         if(GeneralConfig.getInstance().isLoopKillMode()) DELAY = 1;
 
-        loopActivators = new HashMap<>();
-        loopActivatorsToAdd = new ArrayList<>();
-        loopActivatorsToRemove = new ArrayList<>();
+        loopActivators = new ConcurrentHashMap<>();
+        loopActivatorsToAdd = new CopyOnWriteArrayList<>();
+        loopActivatorsToRemove = new CopyOnWriteArrayList<>();
         this.runLoop();
     }
 
@@ -42,9 +46,9 @@ public class LoopManager {
         DELAY = 5;
         if(GeneralConfig.getInstance().isLoopKillMode()) DELAY = 1;
 
-        loopActivators = new HashMap<>();
-        loopActivatorsToAdd = new ArrayList<>();
-        loopActivatorsToRemove = new ArrayList<>();
+        loopActivators = new ConcurrentHashMap<>();
+        loopActivatorsToAdd = new CopyOnWriteArrayList<>();
+        loopActivatorsToRemove = new CopyOnWriteArrayList<>();
         this.runLoop();
     }
 
@@ -125,6 +129,10 @@ public class LoopManager {
                     List<SActivator> loopActivators = new ArrayList<>();
 
                     for (SActivator sActivator : toActivate) {
+                        // Skip activators whose owning plugin got disabled/reloaded since they were
+                        // scheduled: their classloader may already be closed (IllegalStateException:
+                        // zip file closed), and resetLoopActivators() only runs on the next enable.
+                        if (!sActivator.getSPlugin().getPlugin().isEnabled()) continue;
                         if (sActivator.getOption().isLoopOption())
                             loopActivators.add(sActivator);
                     }
@@ -147,7 +155,15 @@ public class LoopManager {
                 }
             }
         };
-        SCore.getSchedulerHook(plugin).runRepeatingTask(runnable, 0L, DELAY);
+        loopTask = SCore.getSchedulerHook(plugin).runRepeatingTask(runnable, 0L, DELAY);
+    }
+
+    /**
+     * Stops the repeating loop task. Called from SCore#onDisable so the task doesn't keep
+     * invoking activators from plugins whose classloader/jar just got closed.
+     */
+    public void shutdown() {
+        if (loopTask != null && !loopTask.isCancelled()) loopTask.cancel();
     }
 
     public void addLoopActivator(SActivator activator) {

--- a/src/main/java/com/ssomar/score/features/custom/blocktitle/BlockTitleFeatures.java
+++ b/src/main/java/com/ssomar/score/features/custom/blocktitle/BlockTitleFeatures.java
@@ -280,20 +280,25 @@ public class BlockTitleFeatures extends FeatureWithHisOwnEditor<BlockTitleFeatur
             }
         } else if (SCore.is1v20v4Plus()) {
             UUID cachedUuid = textDisplayCache.remove(location);
-            if (cachedUuid != null) {
-                Entity entity = Bukkit.getEntity(cachedUuid);
-                if (entity instanceof TextDisplay) {
-                    entity.remove();
-                    return;
+            // Entity manipulation (remove()) must happen on the region thread that owns this
+            // location on Folia — this is a void call so we can just dispatch it there, running
+            // synchronously already if we're on the right thread (no behavior change on non-Folia).
+            SCore.schedulerHook.runLocationTaskAsap(() -> {
+                if (cachedUuid != null) {
+                    Entity entity = Bukkit.getEntity(cachedUuid);
+                    if (entity instanceof TextDisplay) {
+                        entity.remove();
+                        return;
+                    }
                 }
-            }
-            // Fallback for cache miss (e.g., after server restart)
-            for (Entity entity : location.getWorld().getNearbyEntities(location, 0.5, 0.5, 0.5)) {
-                if (entity instanceof TextDisplay && entity.getLocation().equals(location)) {
-                    entity.remove();
-                    break;
+                // Fallback for cache miss (e.g., after server restart)
+                for (Entity entity : location.getWorld().getNearbyEntities(location, 0.5, 0.5, 0.5)) {
+                    if (entity instanceof TextDisplay && entity.getLocation().equals(location)) {
+                        entity.remove();
+                        break;
+                    }
                 }
-            }
+            }, location);
         }
     }
 

--- a/src/main/java/com/ssomar/score/utils/placeholders/StringPlaceholder.java
+++ b/src/main/java/com/ssomar/score/utils/placeholders/StringPlaceholder.java
@@ -441,6 +441,10 @@ public class StringPlaceholder extends PlaceholdersInterface implements Serializ
 
     public String replacePlaceholderOfSCore(String s) {
         String replace = s;
+        // Placeholder occurrences that couldn't be resolved get marked with this sentinel so
+        // lastIndexOf("%score_") stops picking them and the loop can move on to other occurrences,
+        // then it's restored to "%score_" before returning.
+        String unresolvedMarker = " score_";
 
         Pattern SCORE_REGEX = Pattern.compile("%score_*");
         Matcher countSCoreMatcher = SCORE_REGEX.matcher(replace);
@@ -462,29 +466,45 @@ public class StringPlaceholder extends PlaceholdersInterface implements Serializ
             OfflinePlayer p = null;
             if (uuid != null) p = Bukkit.getOfflinePlayer(uuid);
             try {
-                String[] split = replace.split("%score_");
-                String[] split2 = split[1].split("%");
-                String params = split2[0];
+                // Resolve the innermost placeholder first: the last "%score_" occurrence in the
+                // string can't have another "%score_" nested inside it before its closing '%',
+                // unlike the first occurrence which a nested placeholder like
+                // %score_variables_X_%score_variables_Y%% would wrongly pick.
+                int start = replace.lastIndexOf("%score_");
+                if (start == -1) break;
+                int paramStart = start + "%score_".length();
+                int end = replace.indexOf('%', paramStart);
+                if (end == -1) break;
+                String params = replace.substring(paramStart, end);
+
+                String resolvedValue = null;
 
                 Optional<String> placeholder = VariablesManager.getInstance().onRequestPlaceholder(p, params);
-                if (placeholder.isPresent()) replace = replace.replace("%score_" + params + "%", placeholder.get());
+                if (placeholder.isPresent()) resolvedValue = placeholder.get();
 
                 if (p != null) {
+                    if (resolvedValue == null) {
+                        Optional<String> dmgBoosterPlaceHolder = DamageBoost.getInstance().onRequestPlaceholder(p, params);
+                        if (dmgBoosterPlaceHolder.isPresent()) resolvedValue = dmgBoosterPlaceHolder.get();
+                    }
 
-                    Optional<String> dmgBoosterPlaceHolder = DamageBoost.getInstance().onRequestPlaceholder(p, params);
-                    if (dmgBoosterPlaceHolder.isPresent())
-                        replace = replace.replace("%score_" + params + "%", dmgBoosterPlaceHolder.get());
+                    if (resolvedValue == null) {
+                        Optional<String> dmgResistancePlaceHolder = DamageResistance.getInstance().onRequestPlaceholder(p, params);
+                        if (dmgResistancePlaceHolder.isPresent()) resolvedValue = dmgResistancePlaceHolder.get();
+                    }
+                }
 
-                    Optional<String> dmgResistancePlaceHolder = DamageResistance.getInstance().onRequestPlaceholder(p, params);
-                    if (dmgResistancePlaceHolder.isPresent())
-                        replace = replace.replace("%score_" + params + "%", dmgResistancePlaceHolder.get());
+                if (resolvedValue != null) {
+                    replace = replace.substring(0, start) + resolvedValue + replace.substring(end + 1);
+                } else {
+                    replace = replace.substring(0, start) + unresolvedMarker + replace.substring(start + "%score_".length());
                 }
             } catch (Exception e) {
                 e.printStackTrace();
                 break;
             }
         }
-        return replace;
+        return replace.replace(unresolvedMarker, "%score_");
     }
 
     public String replacePlaceholderOfPAPI(String s) {


### PR DESCRIPTION
Fixes from the Hermes release cycle 2026-08 (scope approved 2026-08-08, sources: Discord bugs-errors-issues):

- **Fix `IllegalStateException: zip file closed` spam** from LoopManager global task (classloader race on reload) — [report](https://discord.com/channels/701066025516531753/1519469892993028222)
- **Fix `distance:` argument ignored by `AROUND`** in `blockCommands` — [report](https://discord.com/channels/701066025516531753/1490083941703487759)
- **Fix nested `score_variables` placeholders** (`%score_variables_X_{score_variables_Y}%`) not resolving — [report](https://discord.com/channels/701066025516531753/1527202464145870869)
- **Dispatch Block Title hologram removal to the owning Folia region thread** (partial Folia fix, see commit note)

Builds pass (JDK 25, `--release 8`), SCore unit tests pass. In-game QA pending (see `hermes/releases/2026-08/TEST-REPORT.md` in the workspace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
